### PR TITLE
Display ucc and excomm email on government page

### DIFF
--- a/RuddockWebsite.py
+++ b/RuddockWebsite.py
@@ -427,12 +427,12 @@ def show_gov():
   ucc.sort(key=lambda d: d['office_name'])
   other.sort(key=lambda d: d['office_name'])
 
-  # map the types to their names, so that template can parse efficiently
-  all_types = OrderedDict([
-    ('Executive Committee', excomm),
-    ('Upperclass Counselors', ucc),
-    ('Other Offices', other)
-  ])
+  # tuple with name, email, and users, so that template can parse efficiently
+  all_types = [
+    ('Executive Committee', 'excomm', excomm),
+    ('Upperclass Counselors', 'uccs', ucc),
+    ('Other Offices', None, other)
+  ]
 
   return render_template('government.html', all_types = all_types)
 

--- a/templates/government.html
+++ b/templates/government.html
@@ -3,8 +3,12 @@
 {# TODO: Style this better. #}
 
 {% block body %}
-  {% for name, positions in all_types.iteritems() %}
-    <h2>{{ name }}</h2>
+  {% for name, email, positions in all_types %}
+    {# Display name and email of group #}
+    <div style="text-align:center">
+      <h2 style="display:inline-block">{{ name }}</h2>
+      {{ "[" + email + " at ruddock.caltech.edu" + "]" if email }}
+    </div>
     <table class="userlist">
     {# First display header #}
       <tr>


### PR DESCRIPTION
In addition to individual email addresses, also display email addresses
for uccs@ruddock and excomm@ruddock. This way, users know they can email
all uccs or all of excomm, rather than just one individual.

Completes #40.
