### PR TITLE
Bug fix with authentication

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -10,7 +10,7 @@ def get_user_access_level(username, db):
   #  2    - logged in
   #  3..9 - various offices
   query = text("SELECT IFNULL(MAX(access_level), 2) FROM users NATURAL JOIN" + \
-      " office_members NATURAL JOIN offices WHERE username = :u")
+      " office_members_current NATURAL JOIN offices WHERE username = :u")
   result = db.execute(query, u = username).first()
 
   if (result != None):


### PR DESCRIPTION
We only checked if a user was an office at one point which had
sufficient permissions for viewing a page. However, we should check that
they are CURRENTLY in a position that allows permissions to view a page.
This is a simple fix that uses `office_members_current` instead of
`office_members`.
