### PR TITLE
Fixed link colors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -124,18 +124,22 @@ div.page_title {
 
 a:link {
   text-decoration: none;
+  color: #0000dd;
 }
 
 a:visited {
   text-decoration: none;
+  color: #0000dd;
 }
 
 a:hover {
   text-decoration: underline;
+  color: #0000dd;
 }
 
 a:active {
   text-decoration: underline;
+  color: #0000dd;
 }
 
 a.navbar, a.sub_navbar {


### PR DESCRIPTION
- Set them back to their default color (blue/purple), so that it's clear
  that they actually are links and not just text.
