### PR TITLE
Fix error that prevented server start

### DIFF
--- a/RuddockWebsite.py
+++ b/RuddockWebsite.py
@@ -85,9 +85,8 @@ def teardown_request(exception):
   ''' Logic executed after every request is finished. '''
 
   # Close database connection.
-  db = g.get('db', None)
-  if db != None:
-    db.close()
+  if g.db != None:
+    g.db.close()
 
 @app.route('/')
 def home():


### PR DESCRIPTION
Not sure how we haven't caught this until now (was the server
running an old version of the code?), but upon server restart
we were unable to load anything. This fixes that.

For reference, this was the error:

```
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190] mod_wsgi (pid=10175): Exception occurred processing WSGI script '/var/www/RuddockWebsite/RuddockWebsite.wsgi'.
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190] Traceback (most recent call last):
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1518, in __call__
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     return self.wsgi_app(environ, start_response)
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1507, in wsgi_app
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     return response(environ, start_response)
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/flask/ctx.py", line 167, in __exit__
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     self.pop()
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/flask/ctx.py", line 148, in pop
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     self.app.do_teardown_request()
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1430, in do_teardown_request
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     rv = func(exc)
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/var/www/RuddockWebsite/RuddockWebsite.py", line 88, in teardown_request
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     db = g.get('db', None)
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]   File "/usr/lib/python2.7/dist-packages/werkzeug/local.py", line 336, in __getattr__
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190]     return getattr(self._get_current_object(), name)
[Sat Dec 20 20:34:12 2014] [error] [client 70.196.81.190] AttributeError: '_RequestGlobals' object has no attribute 'get'
```
