### PR TITLE
Add short version of membership description

### DIFF
--- a/RuddockWebsite.py
+++ b/RuddockWebsite.py
@@ -686,21 +686,18 @@ def add_members():
     '''
     This takes a membership description (full member, social member, etc)
     and converts it to the corresponding type. Expects input to be valid
-    and one of (full, social, associate).
+    and one of (full, social, associate, RA).
     '''
-
-    full_regex = re.compile(r'^full(| member)$', re.I)
-    social_regex = re.compile(r'^social(| member)$', re.I)
-    assoc_regex = re.compile(r'^associate(| member)$', re.I)
-
-    if full_regex.match(membership_desc):
-      return 1
-    elif social_regex.match(membership_desc):
-      return 2
-    elif assoc_regex.match(membership_desc):
-      return 3
+    query = text("""
+      SELECT membership_type FROM membership_types
+      WHERE membership_desc = :d
+      OR membership_desc_short = :d
+      """)
+    result = g.db.execute(query, d=membership_desc).first()
+    if result is None:
+      return None
     else:
-      return False
+      return result['membership_type']
 
   def validate_data(data):
     '''
@@ -843,7 +840,7 @@ def add_members():
 
       # Email the user
       subject = "Welcome to the Ruddock House Website!"
-      msg = "Hey " + entry['name'] + ",\n\n" + \
+      msg = "Hey " + entry['fname'] + ' ' + entry['lname'] + ",\n\n" + \
           "You have been added to the Ruddock House Website. In order to " + \
           "access private areas of our site, please complete " + \
           "registration by creating an account here:\n" + \
@@ -882,7 +879,7 @@ def add_members():
     msg = "Hey,\n\n" + \
         "The following members have been added to the Ruddock Website:\n\n"
     for entry in data:
-      msg += entry['name'] + '\n'
+      msg += entry['fname'] + ' ' + entry['lname'] + '\n'
 
     msg += "\nYou should run the email update script to add the new " + \
         "members.\n\n" + \

--- a/RuddockWebsite.py
+++ b/RuddockWebsite.py
@@ -248,24 +248,23 @@ def show_users():
   """ Procedure to show a list of all users, with all membership details. """
   # store which columns we want, and their displaynames
   cols = ["user_id", "lname", "fname", "email", "matriculate_year", \
-          "grad_year", "major", "membership_desc"]
+          "grad_year", "major", "membership_desc_short"]
   display = [None, "Last", "First", "Email", "Matr.", "Grad.", "Major", "Type"]
   fieldMap = dict(zip(cols, display))
 
   # check which table to read from
-  if 'filterType' in request.args and request.args['filterType'] == 'current':
-    tableName = 'members_current'
-    filterType = 'current'
-  elif 'filterType' in request.args and request.args['filterType'] == 'alumni':
-    tableName = 'members_alumni'
-    filterType = 'alumni'
+  filterType = request.args.get('filterType', None)
+  if filterType == 'current':
+    table_name = 'members_current'
+  elif filterType == 'alumni':
+    table_name = 'members_alumni'
   else:
-    tableName = 'members'
-    filterType = 'all'
+    table_name = 'members'
 
   # perform query
-  query = text("SELECT * FROM " + tableName + " NATURAL JOIN membership_types")
-  results = g.db.execute(query)
+  query = text("SELECT * FROM {0} NATURAL JOIN membership_types".format(
+      table_name))
+  results = g.db.execute(query, t=table_name)
 
   # put results in a dictionary
   result_cols = results.keys()

--- a/templates/new_members.html
+++ b/templates/new_members.html
@@ -33,6 +33,7 @@
           <option value="full">Full</option>
           <option value="social">Social</option>
           <option value="associate">Associate</option>
+          <option value="ra">RA</option>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
- Added `membership_desc_short` to database
- House lists displays short version instead of long (helps with narrower screens)
- Use "Full", "Social", "Associate", "RA" instead of "Full Member", "Social Member", etc.
- Also updated how adding members parses the membership type to get the membership type value.