### PR TITLE
Optionally use port in config file

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -1,5 +1,7 @@
 # Note: this file is only used for testing locally. The production environment
 # uses wsgi to start up, and bypasses this file. So we are free to have debug
 # settings enabled.
-from RuddockWebsite import app
-app.run(debug=True)
+from RuddockWebsite import app, config
+
+port = getattr(config, 'PORT', 5000)
+app.run(debug=True, port=port)


### PR DESCRIPTION
If a port is specified in the config file, then use it in
`run_server.py`. Otherwise use 5000. This way, we can each have a
"unique" port that we use that won't conflict with one another.

See #76 for discussion that led to this.