### PR TITLE
Added error handling for 404 and 500 status codes

### DIFF
--- a/RuddockWebsite/__init__.py
+++ b/RuddockWebsite/__init__.py
@@ -1,8 +1,9 @@
+import traceback
 from datetime import datetime
-from flask import Flask, g
+from flask import Flask, g, url_for, render_template, redirect
 from sqlalchemy import create_engine
 
-from RuddockWebsite import config, constants
+from RuddockWebsite import config, constants, email_templates, email_utils
 from RuddockWebsite.modules import account, admin, auth, hassle, users
 
 app = Flask(__name__)
@@ -29,18 +30,36 @@ engine = create_engine(config.DB_URI, convert_unicode=True)
 @app.before_request
 def before_request():
   ''' Logic executed before request is processed. '''
-
   # Connect to the database and publish it in flask.g
   g.db = engine.connect()
 
 @app.teardown_request
 def teardown_request(exception):
   ''' Logic executed after every request is finished. '''
-
   # Close database connection.
   db = getattr(g, 'db', None)
   if db is not None:
     db.close()
+
+# Error handlers
+@app.errorhandler(404)
+def page_not_found(error):
+  ''' Handles a 404 page not found error. '''
+  return render_template("404.html"), 404
+
+@app.errorhandler(500)
+def internal_server_error(error):
+  '''
+  Handles a 500 internal server error response. This error is usually the
+  result of an improperly configured server or bugs in the actual codebase
+  (user errors should be handled gracefully), so IMSS must be notified if this
+  error occurs.
+  '''
+  msg = email_templates.ErrorCaughtEmail.format(traceback.format_exc())
+  subject = "Ruddock website error"
+  to = "imss@ruddock.caltech.edu"
+  email_utils.sendEmail(to, msg, subject)
+  return render_template("500.html"), 500
 
 # After initialization, import the routes.
 from RuddockWebsite import routes

--- a/RuddockWebsite/__init__.py
+++ b/RuddockWebsite/__init__.py
@@ -47,6 +47,11 @@ def page_not_found(error):
   ''' Handles a 404 page not found error. '''
   return render_template("404.html"), 404
 
+@app.errorhandler(403)
+def access_forbidden(error):
+  ''' Handles a 403 access forbidden error. '''
+  return render_template("403.html"), 403
+
 @app.errorhandler(500)
 def internal_server_error(error):
   '''

--- a/RuddockWebsite/decorators.py
+++ b/RuddockWebsite/decorators.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper
-from flask import session, redirect, flash, request, url_for
+from flask import session, redirect, flash, request, url_for, abort
 
 from RuddockWebsite import auth_utils
 
@@ -19,13 +19,10 @@ def login_required(permission=None):
         return redirect(url_for('auth.login'))
 
       # Check permissions.
-      if permission != None:
+      if permission is not None:
         if not auth_utils.check_permission(permission):
-          flash("You do not have permission to access this page.")
-          session['next'] = request.url
-          return redirect(url_for('auth.login'))
+          # Abort with an access forbidden HTTP code.
+          abort(403)
       return fn(*args, **kwargs)
     return update_wrapper(wrapped_function, fn)
   return decorator
-
-

--- a/RuddockWebsite/email_templates.py
+++ b/RuddockWebsite/email_templates.py
@@ -78,3 +78,10 @@ You should run the email update script to add the new members.
 Thanks!
 The Ruddock Website
 '''
+
+ErrorCaughtEmail = \
+'''
+An exception was caught by the website. This is probably a result of a bad server configuration or bugs in the code, so you should look into this. This was the exception:
+
+{}
+'''

--- a/RuddockWebsite/email_utils.py
+++ b/RuddockWebsite/email_utils.py
@@ -4,7 +4,7 @@ from email.mime.text import MIMEText
 
 def sendEmail(to, msg, subject='A message from the Ruddock Website', \
     usePrefix=True):
-  """ Sends an email to a user. """
+  ''' Sends an email to a user. '''
   msg = MIMEText(msg)
 
   if usePrefix and '[RuddWeb]' not in subject:

--- a/RuddockWebsite/templates/403.html
+++ b/RuddockWebsite/templates/403.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block body %}
+<h2>Access forbidden</h2>
+<br>
+You do not have permission to access this resource. If you think this is an error, please find an IMSS rep.
+{% endblock body %}

--- a/RuddockWebsite/templates/404.html
+++ b/RuddockWebsite/templates/404.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block body %}
+<h2>Page not found</h2>
+<br>
+If you were looking for something, this is probably not it.
+{% endblock body %}

--- a/RuddockWebsite/templates/500.html
+++ b/RuddockWebsite/templates/500.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block body %}
+<h2>Server Error</h2>
+<br>
+We encountered an error processing your request, sorry about that. IMSS is automatically notified of these errors, but if the problem persists feel free to find one of us. Thanks!
+{% endblock body %}

--- a/run_server.py
+++ b/run_server.py
@@ -4,4 +4,5 @@
 from RuddockWebsite import app, config
 
 test_port = getattr(config, 'TEST_PORT', 5000)
-app.run(debug=True, port=test_port)
+debug = getattr(config, 'DEBUG', True)
+app.run(debug=debug, port=test_port)


### PR DESCRIPTION
- Shows an custom error page (instead of the default).
- If a 500 internal server error is encountered, IMSS is emailed with
  the traceback.