### PR TITLE
Removed reminder email feature

### DIFF
--- a/RuddockWebsite/modules/admin/helpers.py
+++ b/RuddockWebsite/modules/admin/helpers.py
@@ -219,33 +219,3 @@ class NewMemberList:
       new_member_list.append(new_member)
     self.new_member_list = new_member_list
     return True
-
-def get_members_without_accounts():
-  '''
-  Returns a list of dicts with the first name, last name, email, and
-  user ID for everyone who hasn't made an account yet.
-  '''
-
-  query = text("SELECT fname, lname, email, uid, user_id FROM members \
-      NATURAL LEFT JOIN users WHERE username IS NULL")
-  r = g.db.execute(query)
-  return common_helpers.fetch_all_results(r)
-
-def send_reminder_email(fname, lname, email, user_id, uid):
-  user_hash = common_helpers.create_account_hash(user_id, uid, fname, lname)
-  name = fname + ' ' + lname
-
-  to = email
-  subject = "Please create an account"
-  msg = "Hey " + name + ",\n\n" + \
-      "This is a reminder to create an account on the " + \
-      "Ruddock House Website. You can do this by following this link:\n" + \
-      url_for('create_account', k=user_hash, u=user_id, _external=True) + \
-      "\n\n" + \
-      "If you think this is an error or if you have any other " + \
-      "questions, please contact us at imss@ruddock.caltech.edu" + \
-      "\n\n" + \
-      "Thanks!\n" + \
-      "The Ruddock IMSS Team"
-
-  email_utils.sendEmail(to, msg, subject)

--- a/RuddockWebsite/modules/admin/routes.py
+++ b/RuddockWebsite/modules/admin/routes.py
@@ -15,9 +15,6 @@ def admin_home():
     admin_tools.append({
       'name': 'Add new members',
       'link': url_for('admin.add_members', _external=True)})
-    admin_tools.append({
-      'name': 'Send account creation reminder',
-      'link': url_for('admin.send_reminder_emails', _external=True)})
 
   if auth_utils.check_permission(constants.Permissions.HassleAdmin):
     admin_tools.append({
@@ -90,25 +87,3 @@ def add_members_confirm_submit():
   # An error happened somewhere.
   flash("An unexpected error was encountered. Please find an IMSS rep.")
   return redirect(url_for('admin.add_members'))
-
-@blueprint.route('/reminder_email', methods=['GET', 'POST'])
-@login_required(constants.Permissions.UserAdmin)
-def send_reminder_emails():
-  '''
-  Sends a reminder email to all members who have not yet created
-  an account.
-  '''
-  data = helpers.get_members_without_accounts()
-  state = None
-  if request.method == 'POST' and request.form['state']:
-    state = request.form['state']
-  if state == 'yes':
-    for member in data:
-      helpers.send_reminder_email(member['fname'], \
-          member['lname'], member['email'], member['user_id'], member['uid'])
-    flash('Sent reminder emails to ' + str(len(data)) + ' member(s).')
-    return redirect(url_for('admin.admin_home'))
-  elif state == 'no':
-    return redirect(url_for('admin.admin_home'))
-  else:
-    return render_template('create_account_reminder.html', data=data)


### PR DESCRIPTION
- It was broken and didn't work with the revised account creation
  process.
- Planning on revisiting how that process works.