### PR TITLE
Change max age of connection

### DIFF
--- a/RuddockWebsite/__init__.py
+++ b/RuddockWebsite/__init__.py
@@ -25,7 +25,10 @@ app.register_blueprint(hassle.blueprint, url_prefix='/hassle')
 app.register_blueprint(users.blueprint, url_prefix='/users')
 
 # Create database engine object.
-engine = create_engine(config.DB_URI, convert_unicode=True)
+engine = create_engine(
+    config.DB_URI,
+    convert_unicode=True,
+    pool_recycle=constants.POOL_RECYCLE_TIME)
 
 @app.before_request
 def before_request():

--- a/RuddockWebsite/constants.py
+++ b/RuddockWebsite/constants.py
@@ -1,5 +1,8 @@
 # Store various constants here
 
+# Our MySQL wait_timeout is set to 28800, so set pool timeout to something less.
+POOL_RECYCLE_TIME = 25000
+
 # Maximum file upload size (in bytes).
 MAX_CONTENT_LENGTH = 1 * 1024 * 1024 * 1024
 


### PR DESCRIPTION
Use the `pool_recycle` option to set the maximum age of connection
to something less than the MySQL `wait_timeout` value.

http://docs.sqlalchemy.org/en/latest/core/pooling.html#setting-pool-recycle
https://mofanim.wordpress.com/2013/01/02/sqlalchemy-mysql-has-gone-away/
