### PR TITLE
Style

### DIFF
--- a/RuddockWebsite/__init__.py
+++ b/RuddockWebsite/__init__.py
@@ -1,6 +1,6 @@
 import traceback
 import httplib
-from datetime import datetime
+import datetime
 import flask
 import sqlalchemy
 
@@ -15,7 +15,7 @@ app.secret_key = config.SECRET_KEY
 app.config['MAX_CONTENT_LENGTH'] = constants.MAX_CONTENT_LENGTH
 
 # Update jinja global functions
-app.jinja_env.globals.update(current_year=lambda: datetime.now().year)
+app.jinja_env.globals.update(current_year=lambda: datetime.datetime.now().year)
 
 # Load blueprint modules
 app.register_blueprint(account.blueprint, url_prefix='/account')

--- a/RuddockWebsite/auth_utils.py
+++ b/RuddockWebsite/auth_utils.py
@@ -1,20 +1,20 @@
-'''
+"""
 This module provides library classes and functions for everything concerning
 authentication and authorization, including logins and permissions.
-'''
+"""
 
 import hashlib
 import binascii
 import string
-from sqlalchemy import text
-from flask import session, g, url_for, flash, request, redirect
+import sqlalchemy
+import flask
 
 from RuddockWebsite import constants
 from RuddockWebsite.constants import Permissions
 from RuddockWebsite import misc_utils
 
 class PasswordHashParser:
-  '''
+  """
   Class to manage parsed password hashes.
 
   Handling of current and legacy hashing algorithms:
@@ -48,7 +48,7 @@ class PasswordHashParser:
   generate a new salt, and then append the new algorithm, number of rounds, and
   salt to the modular hash formatted string). Upgrading algorithms with this
   design should be invisible to users.
-  '''
+  """
 
   # Static list of supported hashing algorithms.
   valid_algorithms = ['md5', 'pbkdf2_sha256']
@@ -74,11 +74,11 @@ class PasswordHashParser:
       self.password_hash = None
 
   def __str__(self):
-    '''
+    """
     Method to convert object into string. This method is overridden to convert
     the object into the full hash string it was generated from. Can also be
     used to generate a full hash string.
-    '''
+    """
     # Must be initialized to some valid state.
     if not self.check_self():
       return None
@@ -90,14 +90,14 @@ class PasswordHashParser:
     algorithm_str = '|'.join(algorithms)
     rounds_str = '|'.join(rounds)
     salt_str = '|'.join(salts)
-    return "${0}${1}${2}${3}".format(algorithm_str, rounds_str, salt_str, \
+    return "${0}${1}${2}${3}".format(algorithm_str, rounds_str, salt_str,
         self.password_hash)
 
   def check_self(self):
-    '''
+    """
     This helper checks if this object is currently in a state that is valid for
     checking passwords.  Returns True if successful.
-    '''
+    """
     # Check that each list is nonempty and of the same length.
     if len(self.algorithms) == 0 \
         or len(self.algorithms) != len(self.rounds) \
@@ -108,14 +108,15 @@ class PasswordHashParser:
       return False
 
     # Check that each algorithm is supported.
-    return all(x in PasswordHashParser.valid_algorithms for x in self.algorithms)
+    return all(x in PasswordHashParser.valid_algorithms
+        for x in self.algorithms)
 
   def parse(self, full_hash):
-    '''
+    """
     Parses a hash in the format:
       $algorithm1|...|algorithmN$rounds1|...|roundsN$salt1|...|saltN$hash
     Returns True if successful, False if something unexpected happens.
-    '''
+    """
     hash_components = full_hash.split('$')
     # Expect 5 components (empty string, algorithms, rounds, salts, hash).
     if len(hash_components) != 5 or hash_components[0] != '':
@@ -133,7 +134,7 @@ class PasswordHashParser:
     # Rounds must be integers. If empty string, set to None (not all algorithms
     # supported use key stretching).
     try:
-      rounds = [int(x) if len(x) != 0 else None for x in rounds]
+      rounds = list(int(x) if len(x) != 0 else None for x in rounds)
     except ValueError:
       # Something wasn't an integer.
       return False
@@ -147,10 +148,10 @@ class PasswordHashParser:
     return self.check_self()
 
   def verify_password(self, password):
-    '''
+    """
     Verifies a password by applying each algorithm in turn to the password.
     Returns True if successful, else False.
-    '''
+    """
     # Check that we're in a state to check a password.
     if not self.check_self():
       return False
@@ -165,18 +166,18 @@ class PasswordHashParser:
       # In case an error occurs.
       if test_hash is None:
         return False
-    return compare_secure_strings(test_hash, true_hash)
+    return misc_utils.compare_secure_strings(test_hash, true_hash)
 
   def is_legacy(self):
-    '''
+    """
     Returns true if the hashing algorithm is not the most current version.
-    '''
+    """
     return len(self.algorithms) != 1 or \
         self.algorithms[0] != constants.PWD_HASH_ALGORITHM or \
         self.rounds[0] != constants.HASH_ROUNDS
 
 def hash_password(password, salt, rounds, algorithm):
-  '''
+  """
   Hashes the password with the salt and algorithm provided. The supported
   algorithms are in PasswordHashParser.valid_algorithms.
 
@@ -185,7 +186,7 @@ def hash_password(password, salt, rounds, algorithm):
 
   Algorithms using the passlib library are returned in base64 format.
   Algorithms using the hashlib library are returned in hex format.
-  '''
+  """
   if algorithm == 'pbkdf2_sha256':
     # Rounds must be set.
     if rounds is None:
@@ -198,7 +199,7 @@ def hash_password(password, salt, rounds, algorithm):
   return None
 
 def set_password(username, password):
-  ''' Sets the user's password. Automatically generates a new salt. '''
+  """ Sets the user's password. Automatically generates a new salt. """
   algorithm = constants.PWD_HASH_ALGORITHM
   rounds = constants.HASH_ROUNDS
   salt = generate_salt()
@@ -212,27 +213,31 @@ def set_password(username, password):
   # Sanity check
   if full_hash is None:
     raise ValueError
-  query = text("UPDATE users SET password_hash=:ph WHERE username=:u")
+  query = sqlalchemy.text("""
+    UPDATE users
+    SET password_hash=:ph
+    WHERE username=:u
+    """)
   g.db.execute(query, ph=full_hash, u=username)
   return
 
 def generate_salt():
-  ''' Generates a pseudorandom salt. '''
+  """ Generates a pseudorandom salt. """
   return misc_utils.generate_random_string(constants.SALT_SIZE)
 
 def generate_reset_key():
-  '''
+  """
   Generates a random reset key. We use only digits and lowercase letters since
   the database string comparison is case insensitive (if more entropy is
   needed, just make the string longer).
-  '''
+  """
   chars = string.ascii_lowercase + string.digits
   return misc_utils.generate_random_string(constants.PWD_RESET_KEY_LENGTH,
       chars=chars)
 
 def check_reset_key(reset_key):
-  ''' Returns the username if the reset key is valid, otherwise None. '''
-  query = text("""
+  """ Returns the username if the reset key is valid, otherwise None. """
+  query = sqlalchemy.text("""
     SELECT username
     FROM users
     WHERE password_reset_key = :rk AND NOW() < password_reset_expiration
@@ -244,33 +249,37 @@ def check_reset_key(reset_key):
     return None
 
 def get_user_id(username):
-  ''' Takes a username and returns the user's ID. '''
-  query = text("SELECT user_id FROM users WHERE username = :u")
+  """ Takes a username and returns the user's ID. """
+  query = sqlalchemy.text("SELECT user_id FROM users WHERE username = :u")
   result = g.db.execute(query, u = username).first()
   if result is not None:
     return int(result['user_id'])
   return None
 
 def update_last_login(username):
-  ''' Updates the last login time for the user. '''
-  query = text("UPDATE users SET lastlogin=NOW() WHERE username=:u")
+  """ Updates the last login time for the user. """
+  query = sqlalchemy.text("""
+    UPDATE users
+    SET lastlogin=NOW()
+    WHERE username=:u
+    """)
   g.db.execute(query, u=username)
 
 def generate_create_account_key():
-  '''
+  """
   Generates a random account creation key. Implementation is very similar to
   generate_reset_key().
-  '''
+  """
   chars = string.ascii_lowercase + string.digits
   return misc_utils.generate_random_string(constants.CREATE_ACCOUNT_KEY_LENGTH,
       chars=chars)
 
 def check_create_account_key(key):
-  '''
+  """
   Returns the user_id if the reset key is valid (matches a user_id and that
   user does not already have an account). Otherwise returns None.
-  '''
-  query = text("""
+  """
+  query = sqlalchemy.text("""
     SELECT user_id
     FROM members
     WHERE create_account_key = :k
@@ -282,41 +291,30 @@ def check_create_account_key(key):
   else:
     return None
 
-def compare_secure_strings(string1, string2):
-  '''
-  String comparison function where the time complexity depends only on the
-  length of the string and not the characters themselves. This function must be
-  used for comparing cryptographic strings to prevent side-channel timing
-  attacks.
-  '''
-  result = len(string1) ^ len(string2)
-  for x, y in zip(string1, string2):
-    result |= ord(x) ^ ord(y)
-  return result == 0
-
 def check_login():
-  ''' Returns true if the user is logged in. '''
-  return 'username' in session
+  """ Returns true if the user is logged in. """
+  return 'username' in flask.session
 
-def login_redirect():
-  '''
+def login_flask_redirect():
+  """
   Redirects the user to the login page, saving the intended destination in the
-  sesson variable. This function returns a redirect, so it must be called like this:
+  sesson variable. This function returns a redirect, so it must be called like
+  this:
 
-  return login_redirect()
+  return login_flask.redirect()
 
   In order for it to work properly.
-  '''
-  session['next'] = request.url
-  flash("You must be logged in to visit this page.")
-  return redirect(url_for('auth.login'))
+  """
+  flask.session['next'] = flask.request.url
+  flask.flash("You must be logged in to visit this page.")
+  return flask.redirect(flask.url_for('auth.login'))
 
 def get_permissions(username):
-  '''
+  """
   Returns a list with all of the permissions available to the user.
   A list is returned because Python sets cannot be stored in cookie data.
-  '''
-  query = text("""
+  """
+  query = sqlalchemy.text("""
     (SELECT permission_id
       FROM users
         NATURAL JOIN offices
@@ -333,30 +331,30 @@ def get_permissions(username):
   return list(row['permission_id'] for row in result)
 
 def check_permission(permission):
-  ''' Returns true if the user has the given permission. '''
-  if 'permissions' not in session:
+  """ Returns true if the user has the given permission. """
+  if 'permissions' not in flask.session:
     return False
   # Admins always have access to everything.
-  if Permissions.Admin in session['permissions']:
+  if Permissions.Admin in flask.session['permissions']:
     return True
   # Otherwise check if the permission is present in their permission list.
-  return permission in session['permissions']
+  return permission in flask.session['permissions']
 
 class AdminLink:
-  ''' Simple class to hold link information. '''
+  """ Simple class to hold link information. """
   def __init__(self, name, link):
     self.name = name
     self.link = link
 
 def generate_admin_links():
-  ''' Generates a list of links for the admin page. '''
+  """ Generates a list of links for the admin page. """
   links = []
   if check_permission(Permissions.ModifyUsers):
     links.append(AdminLink('Add members',
-      url_for('admin.add_members', _external=True)))
+      flask.url_for('admin.add_members', _external=True)))
   if check_permission(Permissions.RunHassle):
     links.append(AdminLink('Room hassle',
-      url_for('hassle.run_hassle', _external=True)))
+      flask.url_for('hassle.run_hassle', _external=True)))
   if check_permission(Permissions.EmailAdmin):
     links.append(AdminLink('Mailing lists',
       # This one needs to be hard coded.

--- a/RuddockWebsite/auth_utils.py
+++ b/RuddockWebsite/auth_utils.py
@@ -218,7 +218,7 @@ def set_password(username, password):
     SET password_hash=:ph
     WHERE username=:u
     """)
-  g.db.execute(query, ph=full_hash, u=username)
+  flask.g.db.execute(query, ph=full_hash, u=username)
   return
 
 def generate_salt():
@@ -242,7 +242,7 @@ def check_reset_key(reset_key):
     FROM users
     WHERE password_reset_key = :rk AND NOW() < password_reset_expiration
     """)
-  result = g.db.execute(query, rk=reset_key).first()
+  result = flask.g.db.execute(query, rk=reset_key).first()
   if result is not None:
     return result['username']
   else:
@@ -251,7 +251,7 @@ def check_reset_key(reset_key):
 def get_user_id(username):
   """ Takes a username and returns the user's ID. """
   query = sqlalchemy.text("SELECT user_id FROM users WHERE username = :u")
-  result = g.db.execute(query, u = username).first()
+  result = flask.g.db.execute(query, u = username).first()
   if result is not None:
     return int(result['user_id'])
   return None
@@ -263,7 +263,7 @@ def update_last_login(username):
     SET lastlogin=NOW()
     WHERE username=:u
     """)
-  g.db.execute(query, u=username)
+  flask.g.db.execute(query, u=username)
 
 def generate_create_account_key():
   """
@@ -285,7 +285,7 @@ def check_create_account_key(key):
     WHERE create_account_key = :k
       AND user_id NOT IN (SELECT user_id FROM users)
     """)
-  result = g.db.execute(query, k=key).first()
+  result = flask.g.db.execute(query, k=key).first()
   if result is not None:
     return result['user_id']
   else:
@@ -295,13 +295,13 @@ def check_login():
   """ Returns true if the user is logged in. """
   return 'username' in flask.session
 
-def login_flask_redirect():
+def login_redirect():
   """
   Redirects the user to the login page, saving the intended destination in the
   sesson variable. This function returns a redirect, so it must be called like
   this:
 
-  return login_flask.redirect()
+  return login_redirect()
 
   In order for it to work properly.
   """
@@ -327,7 +327,7 @@ def get_permissions(username):
         NATURAL JOIN user_permissions
       WHERE username=:u)
     """)
-  result = g.db.execute(query, u=username)
+  result = flask.g.db.execute(query, u=username)
   return list(row['permission_id'] for row in result)
 
 def check_permission(permission):

--- a/RuddockWebsite/decorators.py
+++ b/RuddockWebsite/decorators.py
@@ -1,10 +1,11 @@
-from functools import update_wrapper
-from flask import session, redirect, flash, request, url_for, abort
+import httplib
+import functools
+import flask
 
 from RuddockWebsite import auth_utils
 
 def login_required(permission=None):
-  '''
+  """
   Login required decorator. Requires user to be logged in. If a permission
   is provided, then user must also have the appropriate permissions to
   access the page.
@@ -12,7 +13,7 @@ def login_required(permission=None):
   Note that this function does not necessarily cover every scenario, so if you
   need something specific that is not implemented here, you may need to handle
   it manually instead of relying on this function.
-  '''
+  """
   def decorator(fn):
     def wrapped_function(*args, **kwargs):
       # User must be logged in.
@@ -22,7 +23,7 @@ def login_required(permission=None):
       if permission is not None:
         if not auth_utils.check_permission(permission):
           # Abort with an access forbidden HTTP code.
-          abort(403)
+          flask.abort(httplib.FORBIDDEN)
       return fn(*args, **kwargs)
-    return update_wrapper(wrapped_function, fn)
+    return functools.update_wrapper(wrapped_function, fn)
   return decorator

--- a/RuddockWebsite/email_templates.py
+++ b/RuddockWebsite/email_templates.py
@@ -1,5 +1,5 @@
 PasswordChangedEmail = \
-'''
+"""
 Hi {0},
 
 Your password has been successfully changed. If you did not request a password
@@ -7,10 +7,10 @@ change, please let an IMSS rep know immediately.
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 ResetPasswordEmail = \
-'''
+"""
 Hi {0},
 
 We have received a request to reset this account's password. If you didn't
@@ -23,10 +23,10 @@ Your link will expire in {2}.
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 ResetPasswordSuccessfulEmail = \
-'''
+"""
 Hi {0},
 
 Your password has been successfully reset. If you did not request a password
@@ -34,10 +34,10 @@ reset, please let an IMSS rep know immediately.
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 CreateAccountSuccessfulEmail = \
-'''
+"""
 Hi {0},
 
 You have just created an account for the Ruddock website with the username
@@ -45,10 +45,10 @@ You have just created an account for the Ruddock website with the username
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 AddedToWebsiteEmail = \
-'''
+"""
 Hi {0},
 
 You have been added to the Ruddock House Website. In order to access private
@@ -61,10 +61,10 @@ imss@ruddock.caltech.edu.
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 MembersAddedEmail = \
-'''
+"""
 The following members have been added to the Ruddock Website:
 
 {0}
@@ -77,11 +77,11 @@ You should run the email update script to add the new members.
 
 Thanks!
 The Ruddock Website
-'''
+"""
 
 ErrorCaughtEmail = \
-'''
+"""
 An exception was caught by the website. This is probably a result of a bad server configuration or bugs in the code, so you should look into this. This was the exception:
 
 {}
-'''
+"""

--- a/RuddockWebsite/email_utils.py
+++ b/RuddockWebsite/email_utils.py
@@ -1,13 +1,14 @@
-# for email
 import smtplib
 from email.mime.text import MIMEText
 
-def sendEmail(to, msg, subject='A message from the Ruddock Website', \
-    usePrefix=True):
-  ''' Sends an email to a user. '''
+def send_email(to, msg, subject, use_prefix=True):
+  """
+  Sends an email to a user. Expects 'to' to be a comma separated string of
+  emails, and for 'msg' and 'subject' to be strings.
+  """
   msg = MIMEText(msg)
 
-  if usePrefix and '[RuddWeb]' not in subject:
+  if use_prefix and '[RuddWeb]' not in subject:
     subject = '[RuddWeb] ' + subject
 
   msg['Subject'] = subject

--- a/RuddockWebsite/misc_utils.py
+++ b/RuddockWebsite/misc_utils.py
@@ -2,11 +2,11 @@ import string
 import random
 
 def generate_random_string(length, chars=None):
-  '''
+  """
   Generates a random string. Chars should be a string or list with the
   characters to choose from. If chars is not provided, then we default to all
   uppercase and lowercase letters plus digits.
-  '''
+  """
   # Sanity check on inputs.
   if not length >= 1:
     raise ValueError
@@ -14,3 +14,15 @@ def generate_random_string(length, chars=None):
   if chars is None:
     chars = string.ascii_letters + string.digits
   return "".join(random.SystemRandom().choice(chars) for i in xrange(length))
+
+def compare_secure_strings(string1, string2):
+  """
+  String comparison function where the time complexity depends only on the
+  length of the string and not the characters themselves. This function must be
+  used for comparing cryptographic strings to prevent side-channel timing
+  attacks.
+  """
+  result = len(string1) ^ len(string2)
+  for x, y in zip(string1, string2):
+    result |= ord(x) ^ ord(y)
+  return result == 0

--- a/RuddockWebsite/modules/account/__init__.py
+++ b/RuddockWebsite/modules/account/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
-blueprint = Blueprint('account', __name__, template_folder='templates')
+import flask
+blueprint = flask.Blueprint('account', __name__, template_folder='templates')
 
 import RuddockWebsite.modules.account.routes

--- a/RuddockWebsite/modules/account/helpers.py
+++ b/RuddockWebsite/modules/account/helpers.py
@@ -1,5 +1,6 @@
-from flask import g, flash
-from sqlalchemy import text
+import flask
+import sqlalchemy
+
 from RuddockWebsite import auth_utils
 from RuddockWebsite import email_templates
 from RuddockWebsite import email_utils
@@ -8,12 +9,12 @@ from RuddockWebsite import validation_utils
 
 def get_user_data(user_id):
   ''' Helper function to get user data. '''
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT fname, lname, uid, matriculate_year, grad_year, email
     FROM members
     WHERE user_id=:uid
     """)
-  return g.db.execute(query, uid=user_id).first()
+  return flask.g.db.execute(query, uid=user_id).first()
 
 def handle_create_account(user_id, username, password, password2, birthday):
   '''
@@ -35,36 +36,36 @@ def handle_create_account(user_id, username, password, password2, birthday):
 
   # Insert new values into the database. Because the password is updated in a
   # separate step, we must use a transaction to execute this query.
-  trans = g.db.begin()
+  trans = flask.g.db.begin()
   try:
     # Insert the new row into users.
-    query = text("""
+    query = sqlalchemy.text("""
       INSERT INTO users (user_id, username, password_hash)
       VALUES (:uid, :u, :ph)
       """)
-    g.db.execute(query, uid=user_id, u=username, ph='')
+    flask.g.db.execute(query, uid=user_id, u=username, ph='')
     # Set the password.
     auth_utils.set_password(username, password)
     # Set the birthday and invalidate the account creation key.
-    query = text("""
+    query = sqlalchemy.text("""
       UPDATE members
       SET bday = :b,
         create_account_key = NULL
       WHERE user_id = :u
       """)
-    g.db.execute(query, b=birthday, u=user_id)
+    flask.g.db.execute(query, b=birthday, u=user_id)
     trans.commit()
   except Exception:
     trans.rollback()
-    flash("An unexpected error occurred. Please find an IMSS rep.")
+    flask.flash("An unexpected error occurred. Please find an IMSS rep.")
     return False
   # Email the user.
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT CONCAT(fname, ' ', lname) AS name, email
     FROM members NATURAL JOIN users
     WHERE username=:u
     """)
-  result = g.db.execute(query, u=username).first()
+  result = flask.g.db.execute(query, u=username).first()
   # Send confirmation email to user.
   email = result['email']
   name = result['name']

--- a/RuddockWebsite/modules/account/helpers.py
+++ b/RuddockWebsite/modules/account/helpers.py
@@ -70,5 +70,5 @@ def handle_create_account(user_id, username, password, password2, birthday):
   name = result['name']
   msg = email_templates.CreateAccountSuccessfulEmail.format(name, username)
   subject = "Thanks for creating an account!"
-  email_utils.sendEmail(email, msg, subject)
+  email_utils.send_email(email, msg, subject)
   return True

--- a/RuddockWebsite/modules/account/routes.py
+++ b/RuddockWebsite/modules/account/routes.py
@@ -1,46 +1,47 @@
-from flask import render_template, redirect, flash, url_for, request
+import flask
+
 from RuddockWebsite import auth_utils
 from RuddockWebsite.modules.account import blueprint, helpers
 
 @blueprint.route('/create/<create_account_key>')
 def create_account(create_account_key):
-  ''' Checks the key. If valid, displays the create account page. '''
+  """ Checks the key. If valid, displays the create account page. """
   user_id = auth_utils.check_create_account_key(create_account_key)
   if user_id is None:
-    flash('Invalid request. Please check your link and try again. If you continue to encounter problems, please find an IMSS rep.')
-    return redirect(url_for('home'))
+    flask.flash('Invalid request. Please check your link and try again. If you continue to encounter problems, please find an IMSS rep.')
+    return flask.redirect(flask.url_for('home'))
 
   user_data = helpers.get_user_data(user_id)
   if user_data is None:
-    flash('An unexpected error occurred. Please find an IMSS rep.')
-    return redirect(url_for('home'))
-  return render_template('create_account.html', user_data=user_data,
+    flask.flash('An unexpected error occurred. Please find an IMSS rep.')
+    return flask.redirect(flask.url_for('home'))
+  return flask.render_template('create_account.html', user_data=user_data,
       key=create_account_key)
 
 @blueprint.route('/create/<create_account_key>/submit', methods=['POST'])
 def create_account_submit(create_account_key):
-  ''' Handles a create account request. '''
+  """ Handles a create account request. """
   user_id = auth_utils.check_create_account_key(create_account_key)
   if user_id is None:
     # Key is invalid.
-    flash("Someone's been naughty.")
-    return redirect(url_for('home'))
-  username = request.form.get('username', None)
-  password = request.form.get('password', None)
-  password2 = request.form.get('password2', None)
-  birthday = request.form.get('birthday', None)
+    flask.flash("Someone's been naughty.")
+    return flask.redirect(flask.url_for('home'))
+  username = flask.request.form.get('username', None)
+  password = flask.request.form.get('password', None)
+  password2 = flask.request.form.get('password2', None)
+  birthday = flask.request.form.get('birthday', None)
   if username is None \
       or password is None \
       or password2 is None \
       or birthday is None:
-    flash('Invalid request.')
-    return redirect(url_for('home'))
+    flask.flash('Invalid request.')
+    return flask.redirect(flask.url_for('home'))
 
   if helpers.handle_create_account(user_id, username, password, password2,
       birthday):
-    flash('Account successfully created.')
-    return redirect(url_for('home'))
+    flask.flash('Account successfully created.')
+    return flask.redirect(flask.url_for('home'))
   else:
     # Flashes already handled.
-    return redirect(url_for('account.create_account',
+    return flask.redirect(flask.url_for('account.create_account',
         create_account_key=create_account_key))

--- a/RuddockWebsite/modules/admin/__init__.py
+++ b/RuddockWebsite/modules/admin/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
-blueprint = Blueprint('admin', __name__, template_folder='templates')
+import flask
+blueprint = flask.Blueprint('admin', __name__, template_folder='templates')
 
 import RuddockWebsite.modules.admin.routes

--- a/RuddockWebsite/modules/admin/helpers.py
+++ b/RuddockWebsite/modules/admin/helpers.py
@@ -83,7 +83,7 @@ class NewMember:
           create_account_key=create_account_key,
           _external=True))
     to = self.email
-    email_utils.sendEmail(to, msg, subject)
+    email_utils.send_email(to, msg, subject)
     return True
 
   def set_membership_type(self):
@@ -151,7 +151,7 @@ class NewMemberList:
     subject = 'Members were added to the Ruddock Website'
     # Don't use prefix since this is being sent to IMSS/Secretary, which have
     # their own prefixes.
-    email_utils.sendEmail(to, msg, subject, usePrefix=False)
+    email_utils.send_email(to, msg, subject, usePrefix=False)
 
   def parse_csv_file(self, filename):
     '''

--- a/RuddockWebsite/modules/admin/routes.py
+++ b/RuddockWebsite/modules/admin/routes.py
@@ -1,5 +1,7 @@
 import tempfile
-from flask import render_template, redirect, flash, url_for, request, g, abort
+import httplib
+import flask
+
 from RuddockWebsite import auth_utils
 from RuddockWebsite.constants import Permissions
 from RuddockWebsite.decorators import login_required
@@ -8,52 +10,52 @@ from RuddockWebsite.modules.admin import blueprint, helpers
 @blueprint.route('/')
 @login_required()
 def admin_home():
-  '''
+  """
   Loads a home page for admins, providing links to various tools.
-  '''
+  """
   links = auth_utils.generate_admin_links()
   # If there are no links, they have no business being here so we return an
   # access denied error.
   if len(links) == 0:
-    abort(403)
-  return render_template('admin.html', links=links)
+    flask.abort(httplib.FORBIDDEN)
+  return flask.render_template('admin.html', links=links)
 
 @blueprint.route('/members/add')
 @login_required(Permissions.ModifyUsers)
 def add_members():
-  ''' Displays a form to add new members. '''
-  return render_template('add_members.html')
+  """ Displays a form to add new members. """
+  return flask.render_template('add_members.html')
 
 @blueprint.route('/members/add/single/confirm', methods=['POST'])
 @login_required(Permissions.ModifyUsers)
 def add_members_single_confirm():
-  ''' Submission endpoint for adding a single member. '''
-  fname = request.form.get('fname', '')
-  lname = request.form.get('lname', '')
-  matriculate_year = request.form.get('matriculate_year', '')
-  grad_year = request.form.get('grad_year', '')
-  uid = request.form.get('uid', '')
-  email = request.form.get('email', '')
-  membership_desc = request.form.get('membership_desc', '')
+  """ Submission endpoint for adding a single member. """
+  fname = flask.request.form.get('fname', '')
+  lname = flask.request.form.get('lname', '')
+  matriculate_year = flask.request.form.get('matriculate_year', '')
+  grad_year = flask.request.form.get('grad_year', '')
+  uid = flask.request.form.get('uid', '')
+  email = flask.request.form.get('email', '')
+  membership_desc = flask.request.form.get('membership_desc', '')
 
   # Check that data was valid.
   new_member = helpers.NewMember(fname, lname, matriculate_year, grad_year,
       uid, email, membership_desc)
   new_member_list = helpers.NewMemberList([new_member])
   if new_member_list.validate_data():
-    return render_template('add_members_confirm.html',
+    return flask.render_template('add_members_confirm.html',
         new_member_list=new_member_list,
         data_string = str(new_member_list))
-  return redirect(url_for('admin.add_members'))
+  return flask.redirect(flask.url_for('admin.add_members'))
 
 @blueprint.route('/members/add/multi/confirm', methods=['POST'])
 @login_required(Permissions.ModifyUsers)
 def add_members_multi_confirm():
-  ''' Submission endpoint for adding multiple members at a time. '''
-  new_members_file = request.files.get('new_members_file', None)
+  """ Submission endpoint for adding multiple members at a time. """
+  new_members_file = flask.request.files.get('new_members_file', None)
   if new_members_file is None:
-    flash("You must upload a file!")
-    return redirect(url_for('admin.add_members'))
+    flask.flash("You must upload a file!")
+    return flask.redirect(flask.url_for('admin.add_members'))
   # Save the file to a tempfile so we can parse it.
   f = tempfile.NamedTemporaryFile()
   f.write(new_members_file.read())
@@ -62,24 +64,24 @@ def add_members_multi_confirm():
   new_member_list = helpers.NewMemberList()
   if new_member_list.parse_csv_file(f.name):
     if new_member_list.validate_data():
-      return render_template('add_members_confirm.html',
+      return flask.render_template('add_members_confirm.html',
           new_member_list=new_member_list,
           data_string = str(new_member_list))
-  return redirect(url_for('admin.add_members'))
+  return flask.redirect(flask.url_for('admin.add_members'))
 
 @blueprint.route('/members/add/confirm/submit', methods=['POST'])
 @login_required(Permissions.ModifyUsers)
 def add_members_confirm_submit():
-  ''' Handles new member creation. '''
+  """ Handles new member creation. """
   # Expects new member data to be passed as a CSV string.
-  new_member_data = request.form.get('new_member_data', None)
+  new_member_data = flask.request.form.get('new_member_data', None)
   # Silently verify data. There shouldn't be any errors if everything is being
   # used as intended.
   new_member_list = helpers.NewMemberList()
   if new_member_list.parse_csv_string(new_member_data):
     if new_member_list.validate_data(flash_errors=False):
       new_member_list.add_members()
-      return redirect(url_for('admin.add_members'))
+      return flask.redirect(flask.url_for('admin.add_members'))
   # An error happened somewhere.
-  flash("An unexpected error was encountered. Please find an IMSS rep.")
-  return redirect(url_for('admin.add_members'))
+  flask.flash("An unexpected error was encountered. Please find an IMSS rep.")
+  return flask.redirect(flask.url_for('admin.add_members'))

--- a/RuddockWebsite/modules/auth/__init__.py
+++ b/RuddockWebsite/modules/auth/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
-blueprint = Blueprint('auth', __name__, template_folder='templates')
+import flask
+blueprint = flask.Blueprint('auth', __name__, template_folder='templates')
 
 import RuddockWebsite.modules.auth.routes

--- a/RuddockWebsite/modules/auth/helpers.py
+++ b/RuddockWebsite/modules/auth/helpers.py
@@ -1,5 +1,6 @@
-from flask import g, url_for
-from sqlalchemy import text
+import flask
+import sqlalchemy
+
 from RuddockWebsite import auth_utils
 from RuddockWebsite import constants
 from RuddockWebsite import email_templates
@@ -7,11 +8,11 @@ from RuddockWebsite import email_utils
 from RuddockWebsite import validation_utils
 
 def authenticate(username, password):
-  '''
+  """
   Takes a username and password and checks if this corresponds to an actual
   user. Returns user_id if successful, else None. If a legacy algorithm is
   used, then the password is rehashed using the current algorithm.
-  '''
+  """
 
   # Make sure the password is not too long (hashing extremely long passwords
   # can be used to attack the site, so we set an upper limit well beyond what
@@ -20,8 +21,12 @@ def authenticate(username, password):
     return None
 
   # Get the correct password hash and user_id from the database.
-  query = text("SELECT user_id, password_hash FROM users WHERE username=:u")
-  result = g.db.execute(query, u=username).first()
+  query = sqlalchemy.text("""
+    SELECT user_id, password_hash
+    FROM users
+    WHERE username=:u
+    """)
+  result = flask.g.db.execute(query, u=username).first()
   if result is None:
     # Invalid username.
     return None
@@ -41,41 +46,45 @@ def authenticate(username, password):
   return None
 
 def handle_forgotten_password(username, email):
-  '''
+  """
   Handles a forgotten password request. Takes a submitted (username, email)
   pair and checks that the email is associated with that username in the
   database. If successful, the user is emailed a reset key. Returns True on
   success, False if the (username, email) pair is not valid.
-  '''
+  """
   # Check username, email pair.
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT user_id, CONCAT(fname, ' ', lname) AS name, email
     FROM members NATURAL JOIN users
     WHERE username=:u
     """)
-  result = g.db.execute(query, u=username).first()
+  result = flask.g.db.execute(query, u=username).first()
 
   if result is not None and email == result['email']:
     name = result['name']
     user_id = result['user_id']
     # Generate a reset key for the user.
     reset_key = auth_utils.generate_reset_key()
-    query = text("""
+    query = sqlalchemy.text("""
       UPDATE users
       SET password_reset_key = :rk,
       password_reset_expiration = NOW() + INTERVAL :time MINUTE
       WHERE username = :u
       """)
-    g.db.execute(query, rk=reset_key,
+    flask.g.db.execute(query, rk=reset_key,
         time=constants.PWD_RESET_KEY_EXPIRATION, u=username)
-    # Determine if we want to say "your link expires in _ minutes" or "_ hours".
+    # Determine if we want to say "your link expires in _ minutes" or
+    # "your link expires in _ hours".
     if constants.PWD_RESET_KEY_EXPIRATION < 60:
-      expiration_time_str = "{} minutes".format(constants.PWD_RESET_KEY_EXPIRATION)
+      expiration_time_str = "{} minutes".format(
+          constants.PWD_RESET_KEY_EXPIRATION)
     else:
-      expiration_time_str = "{} hours".format(constants.PWD_RESET_KEY_EXPIRATION // 60)
+      expiration_time_str = "{} hours".format(
+          constants.PWD_RESET_KEY_EXPIRATION // 60)
     # Send email to user.
     msg = email_templates.ResetPasswordEmail.format(name,
-        url_for('auth.reset_password', reset_key=reset_key, _external=True),
+        flask.url_for('auth.reset_password',
+          reset_key=reset_key, _external=True),
         expiration_time_str)
     subject = "Password reset request"
     email_utils.send_email(email, msg, subject)
@@ -83,28 +92,28 @@ def handle_forgotten_password(username, email):
   return False
 
 def handle_password_reset(username, new_password, new_password2):
-  '''
+  """
   Handles the submitted password reset request. Returns True if successful,
   False otherwise. Also handles all messages displayed to the user.
-  '''
+  """
   if not validation_utils.validate_password(new_password, new_password2):
     return False
 
   auth_utils.set_password(username, new_password)
   # Clean up the password reset key, so that it cannot be used again.
-  query = text("""
+  query = sqlalchemy.text("""
     UPDATE users
     SET password_reset_key = NULL, password_reset_expiration = NULL
     WHERE username = :u
     """)
-  g.db.execute(query, u=username)
+  flask.g.db.execute(query, u=username)
   # Get the user's email.
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT CONCAT(fname, ' ', lname) AS name, email
     FROM members NATURAL JOIN users
     WHERE username=:u
     """)
-  result = g.db.execute(query, u=username).first()
+  result = flask.g.db.execute(query, u=username).first()
   # Send confirmation email to user.
   email = result['email']
   name = result['name']

--- a/RuddockWebsite/modules/auth/helpers.py
+++ b/RuddockWebsite/modules/auth/helpers.py
@@ -78,7 +78,7 @@ def handle_forgotten_password(username, email):
         url_for('auth.reset_password', reset_key=reset_key, _external=True),
         expiration_time_str)
     subject = "Password reset request"
-    email_utils.sendEmail(email, msg, subject)
+    email_utils.send_email(email, msg, subject)
     return True
   return False
 
@@ -110,5 +110,5 @@ def handle_password_reset(username, new_password, new_password2):
   name = result['name']
   msg = email_templates.ResetPasswordSuccessfulEmail.format(name)
   subject = "Password reset successful"
-  email_utils.sendEmail(email, msg, subject)
+  email_utils.send_email(email, msg, subject)
   return True

--- a/RuddockWebsite/modules/auth/routes.py
+++ b/RuddockWebsite/modules/auth/routes.py
@@ -1,85 +1,86 @@
-from flask import render_template, redirect, flash, url_for, request, session
+import flask
+
 from RuddockWebsite import auth_utils
 from RuddockWebsite import constants
 from RuddockWebsite.modules.auth import blueprint, helpers
 
 @blueprint.route('/login')
 def login():
-  ''' Displays the login page. '''
-  return render_template('login.html')
+  """ Displays the login page. """
+  return flask.render_template('login.html')
 
 @blueprint.route('/login/submit', methods=['POST'])
 def login_submit():
-  ''' Handles authentication. '''
-  username = request.form.get('username', None)
-  password = request.form.get('password', None)
+  """ Handles authentication. """
+  username = flask.request.form.get('username', None)
+  password = flask.request.form.get('password', None)
 
   if username is not None and password is not None:
     user_id = helpers.authenticate(username, password)
     if user_id is not None:
       permissions = auth_utils.get_permissions(username)
-      session['username'] = username
-      session['permissions'] = permissions
+      flask.session['username'] = username
+      flask.session['permissions'] = permissions
       # True if there's any reason to show a link to the admin interface.
-      session['show_admin'] = len(auth_utils.generate_admin_links()) > 0
+      flask.session['show_admin'] = len(auth_utils.generate_admin_links()) > 0
       # Update last login time
       auth_utils.update_last_login(username)
 
       # Return to previous page if in session
-      if 'next' in session:
-        redirect_to = session.pop('next')
-        return redirect(redirect_to)
+      if 'next' in flask.session:
+        redirect_to = flask.session.pop('next')
+        return flask.redirect(redirect_to)
       else:
-        return redirect(url_for('home'))
-  flash('Incorrect username or password. Please try again!')
-  return redirect(url_for('auth.login'))
+        return flask.redirect(flask.url_for('home'))
+  flask.flash('Incorrect username or password. Please try again!')
+  return flask.redirect(flask.url_for('auth.login'))
 
 @blueprint.route('/login/forgot')
 def forgot_password():
-  ''' Displays a form for the user to reset a forgotten password. '''
-  return render_template('forgot_password.html')
+  """ Displays a form for the user to reset a forgotten password. """
+  return flask.render_template('forgot_password.html')
 
 @blueprint.route('/login/forgot/submit', methods=['POST'])
 def forgot_password_submit():
-  ''' Handle forgotten password submission. '''
-  username = request.form.get('username', None)
-  email = request.form.get('email', None)
+  """ Handle forgotten password submission. """
+  username = flask.request.form.get('username', None)
+  email = flask.request.form.get('email', None)
 
   if helpers.handle_forgotten_password(username, email):
-    flash("An email with a recovery link has been sent. If you no longer have access to your email (alums), please contact an IMSS rep to recover your account.")
-    return redirect(url_for('auth.login'))
+    flask.flash("An email with a recovery link has been sent. If you no longer have access to your email (alums), please contact an IMSS rep to recover your account.")
+    return flask.redirect(flask.url_for('auth.login'))
   else:
-    flash("Incorrect username and/or email. If you continue to have issues with account recovery, contact an IMSS rep.")
-    return redirect(url_for('auth.forgot_password'))
+    flask.flash("Incorrect username and/or email. If you continue to have issues with account recovery, contact an IMSS rep.")
+    return flask.redirect(flask.url_for('auth.forgot_password'))
 
 @blueprint.route('/login/reset/<reset_key>')
 def reset_password(reset_key):
-  ''' Checks the reset key. If successful, displays the password reset prompt. '''
+  """ Checks the reset key. If successful, displays the password reset prompt. """
   username = auth_utils.check_reset_key(reset_key)
   if username is None:
-    flash('Invalid request. If your link has expired, then you will need to generate a new one. If you continue to encounter problems, please find an IMSS rep.')
-    return redirect(url_for('auth.forgot_password'))
-  return render_template('reset_password.html', username=username,
+    flask.flash('Invalid request. If your link has expired, then you will need to generate a new one. If you continue to encounter problems, please find an IMSS rep.')
+    return flask.redirect(flask.url_for('auth.forgot_password'))
+  return flask.render_template('reset_password.html', username=username,
       reset_key=reset_key)
 
 @blueprint.route('/login/reset/<reset_key>/submit', methods=['POST'])
 def reset_password_submit(reset_key):
-  ''' Handles a password reset request. '''
+  """ Handles a password reset request. """
   username = auth_utils.check_reset_key(reset_key)
   if username is None:
     # Reset key was invalid.
-    flash("Someone's making it on the naughty list this year...")
-    return redirect(url_for('auth.forgot_password'))
-  new_password = request.form.get('password', '')
-  new_password2 = request.form.get('password2', '')
+    flask.flash("Someone's making it on the naughty list this year...")
+    return flask.redirect(flask.url_for('auth.forgot_password'))
+  new_password = flask.request.form.get('password', '')
+  new_password2 = flask.request.form.get('password2', '')
   if helpers.handle_password_reset(username, new_password, new_password2):
-    flash('Password reset was successful.')
-    return redirect(url_for('auth.login'))
+    flask.flash('Password reset was successful.')
+    return flask.redirect(flask.url_for('auth.login'))
   else:
     # Password reset handler handles error flashes.
-    return redirect(url_for('auth.reset_password', reset_key=reset_key))
+    return flask.redirect(flask.url_for('auth.reset_password', reset_key=reset_key))
 
 @blueprint.route('/logout')
 def logout():
-  session.pop('username', None)
-  return redirect(url_for('home'))
+  flask.session.pop('username', None)
+  return flask.redirect(flask.url_for('home'))

--- a/RuddockWebsite/modules/hassle/__init__.py
+++ b/RuddockWebsite/modules/hassle/__init__.py
@@ -1,5 +1,5 @@
-from flask import Blueprint
-blueprint = Blueprint('hassle', __name__, template_folder='templates',
-    static_folder='static')
+import flask
+blueprint = flask.Blueprint('hassle', __name__,
+    template_folder='templates', static_folder='static')
 
 import RuddockWebsite.modules.hassle.routes

--- a/RuddockWebsite/modules/hassle/helpers.py
+++ b/RuddockWebsite/modules/hassle/helpers.py
@@ -1,11 +1,11 @@
-from sqlalchemy import text
-from flask import g
+import flask
+import sqlalchemy
 
 alleys = [1, 2, 3, 4, 5, 6]
 
 def get_all_members():
-  ''' Gets all current members (potential hassle participants). '''
-  query = text("""
+  """ Gets all current members (potential hassle participants). """
+  query = sqlalchemy.text("""
     SELECT user_id, CONCAT(fname, ' ', lname) AS name, grad_year,
       membership_type, membership_desc, user_id IN (
         SELECT user_id FROM hassle_participants
@@ -13,41 +13,41 @@ def get_all_members():
     FROM members_current NATURAL JOIN membership_types
     ORDER BY membership_type, grad_year, name
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_rising_members():
-  ''' Gets IDs for all current frosh, sophomores, and juniors. '''
-  query = text("""
+  """ Gets IDs for all current frosh, sophomores, and juniors. """
+  query = sqlalchemy.text("""
     SELECT user_id
     FROM members_current
     WHERE membership_type = 1
       AND CONCAT(grad_year, '-07-01') > NOW() + INTERVAL 1 YEAR
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_frosh():
-  ''' Gets IDs for all current frosh. '''
-  query = text("""
+  """ Gets IDs for all current frosh. """
+  query = sqlalchemy.text("""
     SELECT user_id
     FROM members_current
     WHERE membership_type = 1
       AND CONCAT(grad_year, '-07-01') > NOW() + INTERVAL 3 YEAR
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_participants():
-  ''' Gets all members participating in the hassle. '''
-  query = text("""
+  """ Gets all members participating in the hassle. """
+  query = sqlalchemy.text("""
     SELECT user_id, CONCAT(fname, ' ', lname) AS name, grad_year,
       membership_type, membership_desc
     FROM members NATURAL JOIN hassle_participants NATURAL JOIN membership_types
     ORDER BY membership_type, grad_year, name
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_available_participants():
-  ''' Gets all participants who have not yet picked a room. '''
-  query = text("""
+  """ Gets all participants who have not yet picked a room. """
+  query = sqlalchemy.text("""
     SELECT user_id, CONCAT(fname, ' ', lname) AS name
     FROM members NATURAL JOIN hassle_participants
     WHERE user_id NOT IN (
@@ -57,22 +57,22 @@ def get_available_participants():
     )
     ORDER BY name
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def set_participants(participants):
-  ''' Sets hassle participants. '''
+  """ Sets hassle participants. """
   # Delete old participants.
-  delete_query = text("DELETE FROM hassle_participants")
-  g.db.execute(delete_query)
+  delete_query = sqlalchemy.text("DELETE FROM hassle_participants")
+  flask.g.db.execute(delete_query)
 
   # Insert new participants.
-  insert_query = text("INSERT INTO hassle_participants (user_id) VALUES (:p)")
+  insert_query = sqlalchemy.text("INSERT INTO hassle_participants (user_id) VALUES (:p)")
   for participant in participants:
-    g.db.execute(insert_query, p=participant)
+    flask.g.db.execute(insert_query, p=participant)
 
 def get_all_rooms():
-  ''' Gets all rooms in the house. '''
-  query = text("""
+  """ Gets all rooms in the house. """
+  query = sqlalchemy.text("""
     SELECT room_number, alley,
       room_number IN (
         SELECT room_number FROM hassle_rooms
@@ -80,20 +80,20 @@ def get_all_rooms():
     FROM rooms
     ORDER BY room_number
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_participating_rooms():
-  ''' Gets all rooms participating in the hassle. '''
-  query = text("""
+  """ Gets all rooms participating in the hassle. """
+  query = sqlalchemy.text("""
     SELECT room_number, alley
     FROM hassle_rooms NATURAL JOIN rooms
     ORDER BY room_number
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_available_rooms():
-  ''' Gets all rooms that have not been picked. '''
-  query = text("""
+  """ Gets all rooms that have not been picked. """
+  query = sqlalchemy.text("""
     SELECT room_number, alley
     FROM hassle_rooms NATURAL JOIN rooms
     WHERE room_number NOT IN (
@@ -101,13 +101,13 @@ def get_available_rooms():
     )
     ORDER BY room_number
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_rooms_remaining():
-  '''
+  """
   Gets the number of rooms remaining for each alley.
   Returns a dict mapping alley to number of remaining rooms.
-  '''
+  """
   alley_counts = dict(zip(alleys, [0] * len(alleys)))
   available_rooms = get_available_rooms()
   for room in available_rooms:
@@ -115,28 +115,28 @@ def get_rooms_remaining():
   return alley_counts
 
 def set_rooms(rooms):
-  ''' Sets rooms available for hassle. '''
+  """ Sets rooms available for hassle. """
   # Delete old rooms.
-  delete_query = text("DELETE FROM hassle_rooms")
-  g.db.execute(delete_query)
+  delete_query = sqlalchemy.text("DELETE FROM hassle_rooms")
+  flask.g.db.execute(delete_query)
 
   # Insert rooms
-  insert_query = text("INSERT INTO hassle_rooms (room_number) VALUES (:r)")
+  insert_query = sqlalchemy.text("INSERT INTO hassle_rooms (room_number) VALUES (:r)")
   for room in rooms:
-    g.db.execute(insert_query, r=room)
+    flask.g.db.execute(insert_query, r=room)
 
 def get_events():
-  ''' Returns events in the hassle. '''
-  query = text("""
+  """ Returns events in the hassle. """
+  query = sqlalchemy.text("""
     SELECT hassle_event_id, user_id, CONCAT(fname, ' ', lname) AS name,
       room_number, alley
     FROM hassle_events NATURAL JOIN members NATURAL JOIN rooms
     ORDER BY hassle_event_id
     """)
-  return g.db.execute(query).fetchall()
+  return flask.g.db.execute(query).fetchall()
 
 def get_events_with_roommates():
-  ''' Returns events with additional roommate information. '''
+  """ Returns events with additional roommate information. """
   events = get_events()
   results = []
 
@@ -152,55 +152,55 @@ def get_events_with_roommates():
   return results
 
 def new_event(user_id, room_number, roommates):
-  ''' Inserts a new event into the database. '''
+  """ Inserts a new event into the database. """
   # Insert event.
-  query = text("""
+  query = sqlalchemy.text("""
     INSERT INTO hassle_events (user_id, room_number) VALUES (:u, :r)
     """)
-  g.db.execute(query, u=user_id, r=room_number)
+  flask.g.db.execute(query, u=user_id, r=room_number)
 
   # Insert roommates.
-  query = text("""
+  query = sqlalchemy.text("""
     INSERT INTO hassle_roommates (user_id, roommate_id) VALUES (:u, :r)
     """)
   for roommate in roommates:
-    g.db.execute(query, u=user_id, r=roommate)
+    flask.g.db.execute(query, u=user_id, r=roommate)
 
 def clear_events(event_id=None):
-  '''
+  """
   Clears hassle events. If event_id is provided, all events after (not
   including) the provided event are cleared. Otherwise, everything is
   cleared.
-  '''
+  """
   if event_id:
-    query = text("""
+    query = sqlalchemy.text("""
       DELETE FROM hassle_roommates
       WHERE user_id IN (
         SELECT user_id FROM hassle_events
         WHERE hassle_event_id >= :e
       )""")
-    g.db.execute(query, e=event_id)
+    flask.g.db.execute(query, e=event_id)
 
-    query = text("DELETE FROM hassle_events WHERE hassle_event_id >= :e")
-    g.db.execute(query, e=event_id)
+    query = sqlalchemy.text("DELETE FROM hassle_events WHERE hassle_event_id >= :e")
+    flask.g.db.execute(query, e=event_id)
   else:
-    g.db.execute(text("DELETE FROM hassle_roommates"))
-    g.db.execute(text("DELETE FROM hassle_events"))
+    flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_roommates"))
+    flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_events"))
 
 def get_roommates(user_id):
-  ''' Gets all roommates for the provided user. '''
-  query = text("""
+  """ Gets all roommates for the provided user. """
+  query = sqlalchemy.text("""
     SELECT roommate_id, CONCAT(fname, ' ', lname) AS name
     FROM hassle_roommates
       JOIN members ON hassle_roommates.roommate_id = members.user_id
     WHERE hassle_roommates.user_id=:u
     ORDER BY name
     """)
-  return g.db.execute(query, u=user_id).fetchall()
+  return flask.g.db.execute(query, u=user_id).fetchall()
 
 def clear_all():
-  ''' Clears all current hassle data. '''
-  g.db.execute(text("DELETE FROM hassle_roommates"))
-  g.db.execute(text("DELETE FROM hassle_events"))
-  g.db.execute(text("DELETE FROM hassle_participants"))
-  g.db.execute(text("DELETE FROM hassle_rooms"))
+  """ Clears all current hassle data. """
+  flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_roommates"))
+  flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_events"))
+  flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_participants"))
+  flask.g.db.execute(sqlalchemy.text("DELETE FROM hassle_rooms"))

--- a/RuddockWebsite/modules/hassle/routes.py
+++ b/RuddockWebsite/modules/hassle/routes.py
@@ -1,5 +1,5 @@
 import json
-from flask import render_template, redirect, flash, url_for, request
+import flask
 
 from RuddockWebsite.constants import Permissions
 from RuddockWebsite.decorators import login_required
@@ -8,13 +8,13 @@ from RuddockWebsite.modules.hassle import blueprint, helpers
 @blueprint.route('/')
 @login_required(Permissions.RunHassle)
 def run_hassle():
-  ''' Logic for room hassles. '''
+  """ Logic for room hassles. """
   available_participants = helpers.get_available_participants()
   available_rooms = helpers.get_available_rooms()
   rooms_remaining = helpers.get_rooms_remaining()
   events = helpers.get_events_with_roommates()
 
-  return render_template('hassle.html',
+  return flask.render_template('hassle.html',
       available_participants=available_participants,
       available_rooms=available_rooms,
       events=events,
@@ -24,105 +24,105 @@ def run_hassle():
 @blueprint.route('/event', methods=['POST'])
 @login_required(Permissions.RunHassle)
 def hassle_event():
-  ''' Submission endpoint for a new event (someone picks a room). '''
-  user_id = request.form.get('user_id', None)
-  room_number = request.form.get('room', None)
-  roommates = request.form.getlist('roommate_id')
+  """ Submission endpoint for a new event (someone picks a room). """
+  user_id = flask.request.form.get('user_id', None)
+  room_number = flask.request.form.get('room', None)
+  roommates = flask.request.form.getlist('roommate_id')
 
   if user_id == None or room_number == None:
-    flash("Invalid request - try again?")
+    flask.flash("Invalid request - try again?")
   else:
     roommates = list(r for r in roommates if r != "none")
 
     # Check for invalid roommate selection.
     if user_id in roommates or len(roommates) != len(set(roommates)):
-      flash("Invalid roommate selection.")
+      flask.flash("Invalid roommate selection.")
     else:
       helpers.new_event(user_id, room_number, roommates)
-  return redirect(url_for('hassle.run_hassle'))
+  return flask.redirect(flask.url_for('hassle.run_hassle'))
 
 @blueprint.route('/restart', defaults={'event_id': None})
 @blueprint.route('/restart/<int:event_id>')
 @login_required(Permissions.RunHassle)
 def hassle_restart(event_id):
-  ''' Handles a restart. '''
-  if event_id == None:
+  """ Handles a restart. """
+  if event_id is None:
     helpers.clear_events()
   else:
     helpers.clear_events(event_id)
-  return redirect(url_for('hassle.run_hassle'))
+  return flask.redirect(flask.url_for('hassle.run_hassle'))
 
 @blueprint.route('/new')
 @login_required(Permissions.RunHassle)
 def new_hassle():
-  ''' Redirects to the first page to start a new room helpers. '''
+  """ Redirects to the first page to start a new room helpers. """
   # Clear old data.
   helpers.clear_all()
-  return redirect(url_for('hassle.new_hassle_participants'))
+  return flask.redirect(flask.url_for('hassle.new_hassle_participants'))
 
 @blueprint.route('/new/participants')
 @login_required(Permissions.RunHassle)
 def new_hassle_participants():
-  ''' Select participants for the room helpers. '''
+  """ Select participants for the room helpers. """
   # Get a list of all current members.
   members = helpers.get_all_members()
-  return render_template('hassle_new_participants.html', members=members)
+  return flask.render_template('hassle_new_participants.html', members=members)
 
 @blueprint.route('/new/participants/submit', methods=['POST'])
 @login_required(Permissions.RunHassle)
 def new_hassle_participants_submit():
-  ''' Submission endpoint for hassle participants. Redirects to next page. '''
+  """ Submission endpoint for hassle participants. Redirects to next page. """
   # Get a list of all participants' user IDs.
-  participants = map(lambda x: int(x), request.form.getlist('participants'))
+  participants = map(lambda x: int(x), flask.request.form.getlist('participants'))
   # Update database with this hassle's participants.
   helpers.set_participants(participants)
-  return redirect(url_for('hassle.new_hassle_rooms'))
+  return flask.redirect(flask.url_for('hassle.new_hassle_rooms'))
 
 @blueprint.route('/new/rooms')
 @login_required(Permissions.RunHassle)
 def new_hassle_rooms():
-  ''' Select rooms available for the room helpers. '''
+  """ Select rooms available for the room helpers. """
   # Get a list of all rooms.
   rooms = helpers.get_all_rooms()
-  return render_template('hassle_new_rooms.html',
+  return flask.render_template('hassle_new_rooms.html',
       rooms=rooms, alleys=helpers.alleys)
 
 @blueprint.route('/new/rooms/submit', methods=['POST'])
 @login_required(Permissions.RunHassle)
 def new_hassle_rooms_submit():
-  ''' Submission endpoint for hassle rooms. Redirects to next page. '''
+  """ Submission endpoint for hassle rooms. Redirects to next page. """
   # Get a list of all room numbers.
-  rooms = map(lambda x: int(x), request.form.getlist('rooms'))
+  rooms = map(lambda x: int(x), flask.request.form.getlist('rooms'))
   # Update database with participating rooms.
   helpers.set_rooms(rooms)
-  return redirect(url_for('hassle.new_hassle_confirm'))
+  return flask.redirect(flask.url_for('hassle.new_hassle_confirm'))
 
 @blueprint.route('/new/confirm')
 @login_required(Permissions.RunHassle)
 def new_hassle_confirm():
-  ''' Confirmation page for new room helpers. '''
+  """ Confirmation page for new room helpers. """
   participants = helpers.get_participants()
   rooms = helpers.get_participating_rooms()
-  return render_template('hassle_new_confirm.html', rooms=rooms, \
+  return flask.render_template('hassle_new_confirm.html', rooms=rooms, \
       participants=participants, alleys=helpers.alleys)
 
 @blueprint.route('/new/confirm/submit', methods=['POST'])
 @login_required(Permissions.RunHassle)
 def new_hassle_confirm_submit():
-  ''' Submission endpoint for confirmation page. '''
+  """ Submission endpoint for confirmation page. """
   # Nothing to do, everything is already in the database.
-  return redirect(url_for('hassle.run_hassle'))
+  return flask.redirect(flask.url_for('hassle.run_hassle'))
 
 @blueprint.route('/ajax/rising')
 @login_required(Permissions.RunHassle)
 def ajax_get_rising_members():
-  ''' AJAX endpoint that returns the user IDs of rising current members. '''
+  """ AJAX endpoint that returns the user IDs of rising current members. """
   results = list(x['user_id'] for x in helpers.get_rising_members())
   return json.dumps(results)
 
 @blueprint.route('/ajax/frosh')
 @login_required(Permissions.RunHassle)
 def ajax_get_frosh():
-  ''' AJAX endpoint that returns the user IDs of current frosh. '''
+  """ AJAX endpoint that returns the user IDs of current frosh. """
   results = list(x['user_id'] for x in helpers.get_frosh())
   return json.dumps(results)

--- a/RuddockWebsite/modules/users/__init__.py
+++ b/RuddockWebsite/modules/users/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
-blueprint = Blueprint('users', __name__, template_folder='templates')
+import flask
+blueprint = flask.Blueprint('users', __name__, template_folder='templates')
 
 import RuddockWebsite.modules.users.routes

--- a/RuddockWebsite/modules/users/helpers.py
+++ b/RuddockWebsite/modules/users/helpers.py
@@ -1,5 +1,5 @@
-from flask import g, session
-from sqlalchemy import text
+import flask
+import sqlalchemy
 from collections import OrderedDict
 
 from RuddockWebsite import auth_utils
@@ -17,8 +17,13 @@ def get_user_info(username):
              "Membership", "Major", "UID", "Is Abroad"]
   # Defines the order and mapping of displayed attributes to sql columns
   d_dict = OrderedDict(zip(display, cols))
-  query = text("SELECT * FROM users NATURAL JOIN members NATURAL JOIN membership_types WHERE username=:u")
-  result = g.db.execute(query, u=str(username))
+  query = sqlalchemy.text("""
+    SELECT * FROM users
+      NATURAL JOIN members
+      NATURAL JOIN membership_types
+    WHERE username=:u
+    """)
+  result = flask.g.db.execute(query, u=username)
 
   values = result.first()
   if not values:
@@ -32,7 +37,7 @@ def get_user_info(username):
 def get_office_info(username):
   ''' Procedure to get a user's officer info. '''
   cols = ["office_name", "elected", "expired"]
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT office_name, elected, expired
     FROM office_members NATURAL JOIN users NATURAL JOIN offices
     WHERE username = :u

--- a/RuddockWebsite/modules/users/helpers.py
+++ b/RuddockWebsite/modules/users/helpers.py
@@ -6,7 +6,7 @@ from RuddockWebsite import auth_utils
 from RuddockWebsite.constants import Permissions
 
 def get_user_info(username):
-  ''' Procedure to get a user's info from the database. '''
+  """ Procedure to get a user's info from the database. """
   cols = [["username"], ["fname", "lname"], ["nickname"], ["bday"], \
           ["email"], ["email2"], ["status"], ["matriculate_year"], \
           ["grad_year"], ["msc"], ["phone"], ["building", "room_num"], \
@@ -35,7 +35,7 @@ def get_user_info(username):
   return (d_dict, values)
 
 def get_office_info(username):
-  ''' Procedure to get a user's officer info. '''
+  """ Procedure to get a user's officer info. """
   cols = ["office_name", "elected", "expired"]
   query = sqlalchemy.text("""
     SELECT office_name, elected, expired
@@ -43,11 +43,11 @@ def get_office_info(username):
     WHERE username = :u
     ORDER BY elected, expired, office_name
   """)
-  return g.db.execute(query, u=str(username))
+  return flask.g.db.execute(query, u=username)
 
 def check_edit_permission(username):
-  ''' Returns true if user has permission to edit page. '''
+  """ Returns true if user has permission to edit page. """
   if not auth_utils.check_login():
     return False
-  return session['username'] == username \
+  return flask.session['username'] == username \
       or auth_utils.check_permission(Permissions.ModifyUsers)

--- a/RuddockWebsite/modules/users/routes.py
+++ b/RuddockWebsite/modules/users/routes.py
@@ -1,6 +1,7 @@
-from flask import render_template, redirect, flash, url_for, request, g, abort
-from sqlalchemy import text
-from time import strftime
+import time
+import httplib
+import flask
+import sqlalchemy
 
 from RuddockWebsite import auth_utils
 from RuddockWebsite.constants import Permissions
@@ -10,7 +11,7 @@ from RuddockWebsite.modules.users import blueprint, helpers
 @blueprint.route('/')
 @login_required()
 def show_users():
-  ''' Procedure to show a list of all users, with all membership details. '''
+  """ Procedure to show a list of all users, with all membership details. """
   # store which columns we want, and their display names
   cols = ["user_id", "fname", "lname", "email", "matriculate_year", \
           "grad_year", "membership_desc"]
@@ -18,7 +19,7 @@ def show_users():
   fieldMap = dict(zip(cols, display))
 
   # check which table to read from
-  filterType = request.args.get('filterType', None)
+  filterType = flask.request.args.get('filterType', None)
   if filterType == 'current':
     tableName = 'members_current'
   elif filterType == 'alumni':
@@ -27,75 +28,84 @@ def show_users():
     tableName = 'members'
 
   # perform query
-  query = text("SELECT * FROM " + tableName + " NATURAL JOIN membership_types" +
-               " ORDER BY fname")
-  membership_data = g.db.execute(query).fetchall()
+  query = sqlalchemy.text("""
+    SELECT * FROM {}
+    NATURAL JOIN membership_types
+    ORDER BY fname
+    """.format(tableName))
+  membership_data = flask.g.db.execute(query).fetchall()
 
   # we also want to map ids to usernames so we can link to individual pages
-  query = text("SELECT user_id, username FROM users")
-  results = g.db.execute(query)
+  query = sqlalchemy.text("SELECT user_id, username FROM users")
+  results = flask.g.db.execute(query)
   idMap = dict(list(results)) # key is user_id, value is username
 
-  return render_template('userlist.html', data=membership_data, fields=cols, \
-      displays=display, idMap=idMap, fieldMap=fieldMap, filterType=filterType)
+  return flask.render_template('userlist.html',
+      data=membership_data, fields=cols,
+      displays=display, idMap=idMap, fieldMap=fieldMap,
+      filterType=filterType)
 
 @blueprint.route('/view/<username>')
 @login_required()
 def show_user_profile(username):
-  ''' Procedure to show a user's profile and membership details. '''
+  """ Procedure to show a user's profile and membership details. """
   d_dict_user, q_dict_user = helpers.get_user_info(username)
   offices = helpers.get_office_info(username)
   editable = helpers.check_edit_permission(username)
 
   if d_dict_user != None and q_dict_user != None:
-    return render_template('view_user.html', display=d_dict_user, \
-        info=q_dict_user, offices=list(offices), strftime=strftime,
+    return flask.render_template('view_user.html', display=d_dict_user,
+        info=q_dict_user, offices=list(offices), strftime=time.strftime,
         perm=editable)
   else:
-    abort(404)
+    flask.abort(httplib.NOT_FOUND)
 
 @blueprint.route('/edit/<username>', methods=['GET', 'POST'])
 @login_required()
 def change_user_settings(username):
-  ''' Show a page for users to edit their information. '''
+  """ Show a page for users to edit their information. """
   # To visit this page, they must be either modifying their own page or be an
   # admin with appropriate permissions.
   if not helpers.check_edit_permission(username):
-    abort(403)
+    flask.abort(httplib.FORBIDDEN)
 
   params = {}
-  tags = ['nickname', 'usenickname', 'bday', 'email', 'email2', 'msc', 'phone', \
-      'building', 'room_num', 'major', 'isabroad']
-  tag_names = ["Nickname", "Use Nickname", "Birthday", "Email Address", \
-      "Alt. Email Address", "MSC", "Phone Number", "Building Name", "Room Number", \
-      "Major", "Is Abroad"]
+  tags = ['nickname', 'usenickname', 'bday', 'email', 'email2', 'msc',
+      'phone', 'building', 'room_num', 'major', 'isabroad']
+  tag_names = ["Nickname", "Use Nickname", "Birthday", "Email Address",
+      "Alt. Email Address", "MSC", "Phone Number", "Building Name",
+      "Room Number", "Major", "Is Abroad"]
 
   # Get stored values from database
-  query = text("SELECT * FROM users NATURAL JOIN members WHERE username=:u")
-  result = g.db.execute(query, u=str(username))
+  query = sqlalchemy.text("""
+    SELECT * FROM users
+      NATURAL JOIN members
+    WHERE username=:u
+    """)
+  result = flask.g.db.execute(query, u=username)
   if result.returns_rows and result.rowcount != 0:
     result_cols = result.keys()
     r = result.first()
     stored_params = dict(zip(result_cols, r)) #stored_params maps sql columns to values
 
   # Update if needed
-  if request.method == 'POST':
+  if flask.request.method == 'POST':
     for (i, tag) in enumerate(tags):
-      params[tag] = request.form[tag]
+      params[tag] = flask.request.form[tag]
       if params[tag] and tag in ['usenickname', 'msc', 'room_num', 'isabroad']:
         try:
           params[tag] = int(params[tag])
         except:
-          flash("Invalid input for field %s - your change was not saved!" % tag_names[i])
+          flask.flash("Invalid input for field %s - your change was not saved!" % tag_names[i])
           params[tag] = stored_params[tag]
 
     for (i, tag) in enumerate(tags):
       if str(params[tag]) != str(stored_params[tag]):
         new_val = str(params[tag])
-        query = text("UPDATE members SET %s = :val WHERE user_id = :u" % tag)
-        results = g.db.execute(query, \
+        query = sqlalchemy.text("UPDATE members SET %s = :val WHERE user_id = :u" % tag)
+        results = flask.g.db.execute(query,
             u=auth_utils.get_user_id(username), val=new_val)
-        flash("%s was updated!" % tag_names[i])
+        flask.flash("%s was updated!" % tag_names[i])
   if not params:
     params = stored_params
-  return render_template('edit_user.html', params=params)
+  return flask.render_template('edit_user.html', params=params)

--- a/RuddockWebsite/routes.py
+++ b/RuddockWebsite/routes.py
@@ -1,6 +1,6 @@
-from flask import request, session, g, redirect, url_for, abort, \
-    render_template, flash
-from sqlalchemy import text
+import flask
+import sqlalchemy
+
 from RuddockWebsite import app
 from RuddockWebsite import constants
 from RuddockWebsite import email_utils
@@ -8,12 +8,12 @@ from RuddockWebsite.decorators import login_required
 
 @app.route('/')
 def home():
-  return render_template('index.html')
+  return flask.render_template('index.html')
 
 @app.route('/government')
 def show_gov():
   # Get current officers
-  query = text("""
+  query = sqlalchemy.text("""
     SELECT CONCAT(fname, ' ', lname) AS name, username, office_name,
       office_email, office_id, is_excomm, is_ucc
     FROM office_members_current
@@ -21,7 +21,7 @@ def show_gov():
       NATURAL JOIN members_current
       NATURAL JOIN users
       """)
-  results = g.db.execute(query)
+  results = flask.g.db.execute(query)
 
   # Organize by type (excomm and ucc are special)
   excomm = []
@@ -45,9 +45,8 @@ def show_gov():
     ('Upperclass Counselors', 'uccs', ucc),
     ('Other Offices', None, other)
   ]
-
-  return render_template('government.html', all_types = all_types)
+  return flask.render_template('government.html', all_types = all_types)
 
 @app.route('/contact')
 def show_contact():
-  return render_template('contact.html')
+  return flask.render_template('contact.html')

--- a/RuddockWebsite/tests/auth/test_auth_utils.py
+++ b/RuddockWebsite/tests/auth/test_auth_utils.py
@@ -1,4 +1,6 @@
-"""Tests RuddockWebsite/auth_utils.py."""
+"""
+Tests RuddockWebsite/auth_utils.py.
+"""
 import random
 import pytest
 import binascii
@@ -71,5 +73,5 @@ def test_compare_secure_strings():
   assert string1 != string2
 
   # Make sure compare_secure_strings returns True and False when expected.
-  assert auth_utils.compare_secure_strings(string1, string1) == True
-  assert auth_utils.compare_secure_strings(string1, string2) == False
+  assert misc_utils.compare_secure_strings(string1, string1) == True
+  assert misc_utils.compare_secure_strings(string1, string2) == False

--- a/RuddockWebsite/validation_utils.py
+++ b/RuddockWebsite/validation_utils.py
@@ -1,7 +1,8 @@
 import re
 import datetime
-from flask import flash, g
-from sqlalchemy import text
+import flask
+import sqlalchemy
+
 from RuddockWebsite import constants
 
 username_regex = re.compile(r'^[a-z][a-z0-9_-]*$', re.I)
@@ -11,10 +12,10 @@ year_regex = re.compile(r'^[0-9]{4}$')
 email_regex = re.compile(r'^[a-z0-9\.\_\%\+\-]+@[a-z0-9\.\-]+\.[a-z]+$', re.I)
 
 def validate_username(username, flash_errors=True):
-  '''
+  """
   Checks to make sure username is valid. If flash_errors is True, then the
   errors will be displayed as flashes. Returns True if valid, else False.
-  '''
+  """
   error = None
   if len(username) == 0:
     error = 'You must provide a username!'
@@ -28,19 +29,19 @@ def validate_username(username, flash_errors=True):
     error = 'Username may contain only alphanumeric characters, hyphens, or underscores and must begin with a letter.'
   else:
     # Check if username is already in use.
-    query = text("SELECT 1 FROM users WHERE username = :u")
-    result = g.db.execute(query, u=username).first()
+    query = sqlalchemy.text("SELECT 1 FROM users WHERE username = :u")
+    result = flask.g.db.execute(query, u=username).first()
     if result is not None:
       error = 'Username is already in use!'
 
   if error is not None:
     if flash_errors:
-      flash(error)
+      flask.flash(error)
     return False
   return True
 
 def validate_password(password, password2, flash_errors=True):
-  '''
+  """
   Checks to make sure a password is valid. password and password2 should be the
   values from both times the user enters a password. If you need to check a
   password outside of the context of a user setting/changing a password, then
@@ -48,7 +49,7 @@ def validate_password(password, password2, flash_errors=True):
   errors will be displayed as flashes.
 
   Returns True if valid, else False.
-  '''
+  """
   error = None
   if len(password) == 0:
     error = 'You must provide a password!'
@@ -65,65 +66,65 @@ def validate_password(password, password2, flash_errors=True):
 
   if error is not None:
     if flash_errors:
-      flash(error)
+      flask.flash(error)
     return False
   return True
 
 def validate_name(name, flash_errors=True):
-  ''' Validates a name. Flashes errors if flash_errors is True. '''
+  """ Validates a name. Flashes errors if flash_errors is True. """
   # Allow letters, spaces, hyphens, and apostrophes.
   # First and last characters must be letters.
   if not name_regex.match(name):
     if flash_errors:
-      flash("'{0}' is not a valid name.".format(name))
+      flask.flash("'{0}' is not a valid name.".format(name))
     return False
   return True
 
 def validate_uid(uid, flash_errors=True):
-  ''' Validates a UID. Flashes errors if flash_errors is True. '''
+  """ Validates a UID. Flashes errors if flash_errors is True. """
   if not uid_regex.match(uid):
     if flash_errors:
-      flash("'{0}' is not a valid UID.".format(uid))
+      flask.flash("'{0}' is not a valid UID.".format(uid))
     return False
   return True
 
 def check_uid_exists(uid):
-  ''' Returns True if the UID exists in the database. '''
+  """ Returns True if the UID exists in the database. """
   if not validate_uid(uid, flash_errors=False):
     return False
 
-  query = text("SELECT 1 FROM members WHERE uid = :uid")
-  result = g.db.execute(query, uid=uid).first()
+  query = sqlalchemy.text("SELECT 1 FROM members WHERE uid = :uid")
+  result = flask.g.db.execute(query, uid=uid).first()
   return result is not None
 
 def validate_year(year, flash_errors=True):
-  ''' Validates a year. Flashes errors if flash_errors is True. '''
+  """ Validates a year. Flashes errors if flash_errors is True. """
   # Also check that the year is in the range supported by MySQL's year type.
   if year_regex.match(year) \
       and int(year) >= 1901 \
       and int(year) <= 2155:
     return True
   if flash_errors:
-    flash("'{0}' is not a valid year.".format(year))
+    flask.flash("'{0}' is not a valid year.".format(year))
   return False
 
 def validate_email(email, flash_errors=True):
-  ''' Validates an email. Flashes errrors if flash_errors is True. '''
+  """ Validates an email. Flashes errrors if flash_errors is True. """
   if not email_regex.match(email):
     if flash_errors:
-      flash("'{0}' is not a valid email.".format(email))
+      flask.flash("'{0}' is not a valid email.".format(email))
     return False
   return True
 
 def validate_birthday(birthday, flash_errors=True):
-  '''
+  """
   Validates birthday string. Format should be YYYY-MM-DD. Flashes errors if
   flash_errors is True.
-  '''
+  """
   try:
     datetime.datetime.strptime(birthday, '%Y-%m-%d')
   except ValueError:
     if flash_errors:
-      flash('Birthday must be in YYYY-MM-DD format.')
+      flask.flash('Birthday must be in YYYY-MM-DD format.')
     return False
   return True

--- a/run_server.py
+++ b/run_server.py
@@ -1,8 +1,12 @@
-# Note: this file is only used for testing locally. The production environment
-# uses wsgi to start up, and bypasses this file. So we are free to have debug
-# settings enabled.
-from RuddockWebsite import app, config
+"""
+Starts an instance of the test server for testing locally. The production
+enviornment uses the wsgi script to start up and bypasses this file, so we are
+free to have debug settings enabled.
+"""
+from RuddockWebsite import app
+from RuddockWebsite import config
 
-test_port = getattr(config, 'TEST_PORT', 5000)
-debug = getattr(config, 'DEBUG', True)
-app.run(debug=debug, port=test_port)
+if __name__ == "__main__":
+  test_port = getattr(config, 'TEST_PORT', 5000)
+  debug = getattr(config, 'DEBUG', True)
+  app.run(debug=debug, port=test_port)


### PR DESCRIPTION
Style cleanup (implements #94), partly to follow PEP8 more closely:
- `'''` becomes `"""`
- `import flask` instead of `from flask import ...`. This also helps remove unused methods that were imported (can be confusing)
- Renamed `sendEmail` to `send_email` to follow convention for everything else

I wanted to do this overhaul now instead of later so we don't have mismatched styles in the codebase (or otherwise having to update more things).