### PR TITLE
Adds support for moving between buckets.

### DIFF
--- a/ruddock/modules/rotation/helpers.py
+++ b/ruddock/modules/rotation/helpers.py
@@ -21,7 +21,7 @@ def get_dinner_prefrosh_by_prefrosh_id(prefrosh_id):
       (SELECT dinner FROM rotation_prefrosh WHERE prefrosh_id = :pid)
     """)
   raw = flask.g.db.execute(query, pid=prefrosh_id).fetchall()
-  return format_prefrosh_list(raw)
+  return postprocess_prefrosh_data(raw)
 
 def get_prefrosh_by_dinner(dinner_id):
   query = sqlalchemy.text("""
@@ -31,7 +31,7 @@ def get_prefrosh_by_dinner(dinner_id):
     FROM rotation_prefrosh NATURAL JOIN rotation_buckets WHERE dinner = (:d)
     """)
   raw = flask.g.db.execute(query, d=dinner_id).fetchall()
-  return format_prefrosh_list(raw)
+  return postprocess_prefrosh_data(raw)
 
 def get_prefrosh_by_bucket(bucket_name):
   query = sqlalchemy.text("""
@@ -41,7 +41,7 @@ def get_prefrosh_by_bucket(bucket_name):
     FROM rotation_prefrosh NATURAL JOIN rotation_buckets WHERE bucket_name = (:b)
     """)
   raw = flask.g.db.execute(query, b=bucket_name).fetchall()
-  return format_prefrosh_list(raw)
+  return postprocess_prefrosh_data(raw)
 
 def get_all_prefrosh():
   query = sqlalchemy.text("""
@@ -51,7 +51,7 @@ def get_all_prefrosh():
     FROM rotation_prefrosh NATURAL JOIN rotation_buckets
     """)
   raw = flask.g.db.execute(query).fetchall()
-  return format_prefrosh_list(raw)
+  return postprocess_prefrosh_data(raw)
 
 def get_image_contents(prefrosh_id):
   query = sqlalchemy.text("""
@@ -102,7 +102,7 @@ def get_prefrosh_and_adjacent(prefrosh_id, prefrosh_list):
   next_id = prefrosh_list[idx + 1]['prefrosh_id'] if idx < len(prefrosh_list) - 1 else None
   return [prefrosh, prev_id, next_id]
 
-def format_prefrosh_list(ls):
+def postprocess_prefrosh_data(ls):
   prefrosh_list = [dict(pf.items()) for pf in ls]
   for prefrosh in prefrosh_list:
     prefrosh['full_name'] = format_name(

--- a/ruddock/modules/rotation/helpers.py
+++ b/ruddock/modules/rotation/helpers.py
@@ -2,7 +2,7 @@ import flask
 import sqlalchemy
 
 DINNERS = range(1, 9)
-BUCKETS = ['000', '-2', '-1', '0', '1', '2', '3']
+BUCKETS = ['000', '-2', '-1', '0', '0.5', '1', '1.5', '2', '3']
 VOTE_TUPLES = [
   {'vote_value': -2, 'vote_string': 'votes_neg_two'},
   {'vote_value': -1, 'vote_string': 'votes_neg_one'},

--- a/ruddock/modules/rotation/routes.py
+++ b/ruddock/modules/rotation/routes.py
@@ -11,13 +11,18 @@ from ruddock.modules.rotation import blueprint, helpers
 @login_required(Permissions.ROTATION)
 def show_portal():
   dinner_list = helpers.DINNERS
+  buckets = helpers.BUCKETS
   return flask.render_template('portal.html',
-    dinner_list=dinner_list)
+    dinner_list=dinner_list, buckets=buckets)
 
+@blueprint.route('/dinner', defaults={'dinner_id': None})
 @blueprint.route('/dinner/<int:dinner_id>')
 @login_required(Permissions.ROTATION)
-def show_dinner_list(dinner_id):
-  prefrosh_list = helpers.get_prefrosh_by_dinner(dinner_id)
+def show_prefrosh_list(dinner_id):
+  if dinner_id:
+    prefrosh_list = helpers.get_prefrosh_by_dinner(dinner_id)
+  else:
+    prefrosh_list = helpers.get_all_prefrosh()
   return flask.render_template('directory.html',
     prefrosh_list=prefrosh_list, dinner_id=dinner_id)
 
@@ -31,7 +36,8 @@ def serve_image(prefrosh_id):
 @blueprint.route('/prefrosh/<int:prefrosh_id>')
 @login_required(Permissions.ROTATION)
 def show_prefrosh(prefrosh_id):
-  prefrosh, prev_id, next_id = helpers.get_prefrosh_and_adjacent(prefrosh_id)
+  dinner_prefrosh = helpers.get_dinner_prefrosh_by_prefrosh_id(prefrosh_id)
+  prefrosh, prev_id, next_id = helpers.get_prefrosh_and_adjacent(prefrosh_id, dinner_prefrosh)
   full_name = helpers.format_name(
     prefrosh['first_name'], prefrosh['last_name'], prefrosh['preferred_name'])
 
@@ -44,3 +50,34 @@ def update_comment(prefrosh_id):
   helpers.update_comments(prefrosh_id, flask.request.form.get("comments", ""))
   helpers.update_votes(prefrosh_id, flask.request.form)
   return flask.redirect(flask.url_for("rotation.show_prefrosh", prefrosh_id=prefrosh_id))
+
+@blueprint.route('/move/', methods=['POST'])
+@login_required(Permissions.ROTATION)
+def move():
+  old_bucket_name = flask.request.form.get("oldBucket")
+  new_bucket_name = flask.request.form.get("newBucket")
+  if old_bucket_name not in helpers.BUCKETS or new_bucket_name not in helpers.BUCKETS:
+    flask.flash("Bad value for one of the buckets.")
+    return flask.redirect(flask.url_for('rotation.show_portal'))
+  elif old_bucket_name == new_bucket_name:
+    flask.flash("Buckets must be distinct")
+    return flask.redirect(flask.url_for('rotation.show_portal'))
+  else:
+    old_bucket_prefrosh = helpers.get_prefrosh_by_bucket(old_bucket_name)
+    new_bucket_prefrosh = helpers.get_prefrosh_by_bucket(new_bucket_name)
+    return flask.render_template('move.html', old_bucket=old_bucket_prefrosh,
+      new_bucket=new_bucket_prefrosh, old_bucket_name=old_bucket_name, new_bucket_name=new_bucket_name,
+      vote_tuples=helpers.VOTE_TUPLES)
+
+@blueprint.route('/change_bucket/<int:prefrosh_id>', methods=['POST'])
+@login_required(Permissions.ROTATION)
+def change_bucket(prefrosh_id):
+  new_bucket_name = flask.request.form.get("newBucket")
+  old_bucket_name = flask.request.form.get("oldBucket")
+  bucket_prefrosh = helpers.get_prefrosh_by_bucket(old_bucket_name)
+  prefrosh, prev_id, next_id = helpers.get_prefrosh_and_adjacent(prefrosh_id, bucket_prefrosh)
+  helpers.change_bucket(prefrosh_id, new_bucket_name)
+  if prev_id:
+    return flask.redirect(flask.url_for("rotation.move", _anchor=prev_id), code=307)
+  else:
+    return flask.redirect(flask.url_for("rotation.move", _anchor=next_id), code=307)

--- a/ruddock/modules/rotation/routes.py
+++ b/ruddock/modules/rotation/routes.py
@@ -57,9 +57,6 @@ def update_comment(prefrosh_id):
 def move():
   old_bucket_name = flask.request.args.get("old_bucket_name")
   new_bucket_name = flask.request.args.get("new_bucket_name")
-  print "@@@@@@@@@@@@@@@@@"
-  print old_bucket_name
-  print new_bucket_name
   if old_bucket_name not in helpers.BUCKETS or new_bucket_name not in helpers.BUCKETS:
     flask.flash("Bad value for one of the buckets.")
     return flask.redirect(flask.url_for('rotation.show_portal'))

--- a/ruddock/modules/rotation/static/css/move.css
+++ b/ruddock/modules/rotation/static/css/move.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.bucketContents {
+  height: 65vh;
+  overflow: scroll;
+}
+
+.prefroshDetails {
+  background-clip: border-box;
+  background-color: lightgray;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 10px;
+}

--- a/ruddock/modules/rotation/static/css/portal.css
+++ b/ruddock/modules/rotation/static/css/portal.css
@@ -1,0 +1,8 @@
+.menuItem {
+  padding-right: 100px;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
+}

--- a/ruddock/modules/rotation/templates/directory.html
+++ b/ruddock/modules/rotation/templates/directory.html
@@ -2,15 +2,13 @@
 
 {% block body %}
 <script src="{{ url_for('static', filename='js/tablesort.min.js') }}"></script>
-<h2>Prefrosh Directory (Dinner {{ dinner_id }})</h2>
+<h2>Prefrosh Directory {{ '(Dinner %d)' % dinner_id if dinner_id is not none else '(All)' }}</h2>
 <a href="{{ url_for('rotation.show_portal') }}">Return to Portal</a>
 <table class="prefroshlist" id="user-table">
   <thead style="cursor: pointer;">
     <tr>
       <th>Image</th>
-      <th>First</th>
-      <th>Preferred</th>
-      <th>Last</th>
+      <th>Name</th>
       <th>Bucket</th>
       <th>-2</th>
       <th>-1</th>
@@ -28,9 +26,7 @@
       <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
       height = "200">
     </td>
-    <td>{{ prefrosh['first_name'] }}</td>
-    <td>{{ prefrosh['preferred_name'] if prefrosh['preferred_name'] is not none else '' }}</td>
-    <td>{{ prefrosh['last_name'] }}</td>
+    <td>{{ prefrosh['full_name'] }}</td>
     <td>{{ prefrosh['bucket_name'] }}</td>
     <td>{{ prefrosh['votes_neg_two'] }}</td>
     <td>{{ prefrosh['votes_neg_one'] }}</td>

--- a/ruddock/modules/rotation/templates/move.html
+++ b/ruddock/modules/rotation/templates/move.html
@@ -1,0 +1,80 @@
+{% extends "layout.html" %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css"
+  href="{{ url_for('rotation.static', filename='css/move.css') }}" />
+{% endblock head %}
+
+{% block body %}
+
+<div class="container">
+  <div>
+    <h2>Bucket {{ old_bucket_name }}</h2>
+    <div class="bucketContents">
+      {% for prefrosh in old_bucket %}
+        <div class="prefroshDetails" id="{{ prefrosh['prefrosh_id'] }}">
+          <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
+        height = "300">
+          <a href="{{ url_for('rotation.show_prefrosh',
+        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'] }}</a>
+          <div class="container">
+            <table>
+              <thead>
+                <tr>
+                  {% for vote_tuple in vote_tuples %}
+                    <th>{{ vote_tuple['vote_value'] }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {% for vote_tuple in vote_tuples %}
+                    <td>{{ prefrosh[vote_tuple['vote_string']] }}</td>
+                  {% endfor %}
+                </tr>
+              </tbody>
+            </table>
+            <form action="{{ url_for('rotation.change_bucket', prefrosh_id=prefrosh['prefrosh_id']) }}"
+              method="post" id="change_bucket_form">
+              <input type="hidden" name="oldBucket" value="{{ old_bucket_name }}">
+              <input type="hidden" name="newBucket" value="{{ new_bucket_name }}">
+              <input type="submit" value="Move">
+            </form>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div>
+    <h2>Bucket {{ new_bucket_name }}</h2>
+    <div class="bucketContents">
+      {% for prefrosh in new_bucket %}
+        <div class="prefroshDetails" id="{{ prefrosh['prefrosh_id'] }}">
+          <img src="{{ url_for('rotation.serve_image', prefrosh_id=prefrosh['prefrosh_id']) }}"
+        height = "300">
+          <a href="{{ url_for('rotation.show_prefrosh',
+        prefrosh_id=prefrosh['prefrosh_id']) }}">{{ prefrosh['full_name'] }}</a>
+          <div class="container">
+            <table>
+              <thead>
+                <tr>
+                  {% for vote_tuple in vote_tuples %}
+                    <th>{{ vote_tuple['vote_value'] }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {% for vote_tuple in vote_tuples %}
+                    <td>{{ prefrosh[vote_tuple['vote_string']] }}</td>
+                  {% endfor %}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endblock body %}

--- a/ruddock/modules/rotation/templates/move.html
+++ b/ruddock/modules/rotation/templates/move.html
@@ -46,6 +46,9 @@
     </div>
   </div>
   <div>
+    <a href="{{ url_for('rotation.show_portal') }}">Return To Portal</a>
+  </div>
+  <div>
     <h2>Bucket {{ new_bucket_name }}</h2>
     <div class="bucketContents">
       {% for prefrosh in new_bucket %}

--- a/ruddock/modules/rotation/templates/portal.html
+++ b/ruddock/modules/rotation/templates/portal.html
@@ -1,11 +1,41 @@
 {% extends "layout.html" %}
 
-{% block body %}
-<h2>Dinners</h2>
+{% block head %}
+<link rel="stylesheet" type="text/css"
+  href="{{ url_for('rotation.static', filename='css/portal.css') }}" />
+{% endblock head %}
 
-{% for dinner in dinner_list %}
-  <a href="{{ url_for('rotation.show_dinner_list', dinner_id=dinner) }}">Dinner {{ dinner }}</a>
-  <br>
-{% endfor %}
+{% block body %}
+<div class="container">
+  <div class="menuItem">
+    <h2>Dinners</h2>
+    {% for dinner in dinner_list %}
+      <a href="{{ url_for('rotation.show_prefrosh_list', dinner_id=dinner) }}">Dinner {{ dinner }}</a>
+      <br>
+    {% endfor %}
+    <a href="{{ url_for('rotation.show_prefrosh_list') }}">All Prefrosh</a>
+  </div>
+  <div class="menuItem">
+    <h2>Move Prefrosh</h2>
+    <form action="{{ url_for('rotation.move') }}" method="post" id="bucket_form">
+      <label>Old Bucket:</label>
+      <select name="oldBucket">
+        {% for bucket in buckets %}
+          <option value="{{ bucket }}">{{ bucket }}</option>
+        {% endfor %}
+      </select>
+      <br>
+      <label>New Bucket:</label>
+      <select name="newBucket">
+        {% for bucket in buckets %}
+          <option value="{{ bucket }}">{{ bucket }}</option>
+        {% endfor %}
+      </select>
+      <br>
+      <input type="submit">
+    </form>
+  </div>
+</div>
+
 
 {% endblock body %}

--- a/ruddock/modules/rotation/templates/portal.html
+++ b/ruddock/modules/rotation/templates/portal.html
@@ -17,16 +17,16 @@
   </div>
   <div class="menuItem">
     <h2>Move Prefrosh</h2>
-    <form action="{{ url_for('rotation.move') }}" method="post" id="bucket_form">
+    <form action="{{ url_for('rotation.move') }}" method="get" id="bucket_form">
       <label>Old Bucket:</label>
-      <select name="oldBucket">
+      <select name="old_bucket_name">
         {% for bucket in buckets %}
           <option value="{{ bucket }}">{{ bucket }}</option>
         {% endfor %}
       </select>
       <br>
       <label>New Bucket:</label>
-      <select name="newBucket">
+      <select name="new_bucket_name">
         {% for bucket in buckets %}
           <option value="{{ bucket }}">{{ bucket }}</option>
         {% endfor %}

--- a/ruddock/modules/rotation/templates/prefrosh.html
+++ b/ruddock/modules/rotation/templates/prefrosh.html
@@ -16,7 +16,7 @@
 </script>
 
 {% if prefrosh['dinner'] is not none %}
-  <a href="{{ url_for('rotation.show_dinner_list', dinner_id=prefrosh['dinner']) }}">Return to Dinner</a>
+  <a href="{{ url_for('rotation.show_prefrosh_list', dinner_id=prefrosh['dinner']) }}">Return to Dinner</a>
 {% endif %}
 {% if prev_id is not none %}
   <br>
@@ -26,6 +26,7 @@
   <br>
   <a href ="{{ url_for('rotation.show_prefrosh', prefrosh_id=next_id) }}">Next</a>
 {% endif %}
+
 <h1>{{ full_name }}</h1>
 <div class="container">
   <div>


### PR DESCRIPTION
Creates a new view on the main portal- a dropdown to select two
distinct buckets to compare.

Creates a comparison page which holds two scrollable divs for the two
buckets. Prefrosh can be moved from the left bucket to the right bucket
using the 'move' button. Scroll position is maintained after a move.

Minor improvements: 
The directory view is simplified to show the full prefrosh name in a single 
column instead of being split across three columns.
Added a 'view all prefrosh' link to the main page. 