### PR TITLE
Bugfix: Government page not showing officers

### DIFF
--- a/ruddock/modules/government/templates/government.html
+++ b/ruddock/modules/government/templates/government.html
@@ -15,7 +15,12 @@
       </tr></thead>
       {# Now, display each row #}
       {% for position in positions %}
+        {# Yes, jinja2 has a test called 'none' and it's not spelled 'None' #}
+        {% if position['username'] is not none %}
         <tr class="link" onclick="location.href='{{ url_for('users.view_profile', username=position['username']) }}'">
+        {% else %}
+        <tr>
+        {% endif %}
           <td>{{ position['office_name'] }}</td>
           <td>{{ position['name'] }}</td>
           <td>{{ position['office_email'] if position['office_email'] else '[None]' }}</td>

--- a/ruddock/office_utils.py
+++ b/ruddock/office_utils.py
@@ -11,7 +11,7 @@ FROM office_assignments
   NATURAL JOIN offices
   NATURAL JOIN members
   NATURAL JOIN members_extra
-  NATURAL JOIN users
+  NATURAL LEFT JOIN users
 {0}
 ORDER BY office_order, start_date, name
 """


### PR DESCRIPTION
Specifically, if someone didn't have an account, they didn't show up.
Now the relevant query uses a left join against the user accounts
table, so it should always succeed in fetching a member.