### PR TITLE
Add Vim swp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ target/
 # OS X generated files
 .DS_Store
 ._*
+
+# Vim swp files
+*.swp


### PR DESCRIPTION
Prevent committing temporary Vim swap files to the repository.