### PR TITLE
Feature/2021 prefrosh

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -180,7 +180,6 @@ CREATE TABLE rotation_prefrosh (
   first_name VARCHAR(255) NOT NULL,
   last_name VARCHAR(255) NOT NULL,
   preferred_name VARCHAR(255),
-  image LONGBLOB,
   bucket_id INTEGER,
   votes_neg_two INTEGER NOT NULL DEFAULT 0,
   votes_neg_one INTEGER NOT NULL DEFAULT 0,
@@ -191,6 +190,7 @@ CREATE TABLE rotation_prefrosh (
   dinner INTEGER, -- defined in rotation/helpers.py (1-8)
   attended_dinner BOOLEAN,
   comments VARCHAR(60000),
+  image_name VARCHAR(255),
   PRIMARY KEY (prefrosh_id),
   FOREIGN KEY (bucket_id) REFERENCES rotation_buckets (bucket_id)
 );

--- a/ruddock/__init__.py
+++ b/ruddock/__init__.py
@@ -63,6 +63,7 @@ def init(environment_name):
   app.config["DEBUG"] = environment.debug
   app.config["TESTING"] = environment.testing
   app.config["SECRET_KEY"] = environment.secret_key
+  app.config["MEDIA_FOLDER"] = environment.media_folder;
 
   # Maximum file upload size, in bytes.
   app.config["MAX_CONTENT_LENGTH"] = constants.MAX_CONTENT_LENGTH

--- a/ruddock/default_config.py
+++ b/ruddock/default_config.py
@@ -1,6 +1,8 @@
 """Default website configurations, used only for testing.
 """
 
+import os
+
 from ruddock import environment
 
 TEST = environment.Environment(
@@ -10,4 +12,7 @@ TEST = environment.Environment(
     db_password="public",
     debug=True,
     testing=True,
-    secret_key="1234567890")
+    secret_key="1234567890",
+    media_folder=os.path.abspath("media"))
+
+#TODO is there a better way of getting media_folder?

--- a/ruddock/environment.py
+++ b/ruddock/environment.py
@@ -13,7 +13,7 @@ class Environment(object):
   """
 
   def __init__(self, db_hostname, db_name, db_user, db_password, debug,
-      testing, secret_key):
+      testing, secret_key, media_folder):
     self.db_hostname = db_hostname
     self.db_name = db_name
     self.db_user = db_user
@@ -21,6 +21,7 @@ class Environment(object):
     self.debug = debug
     self.testing = testing
     self.secret_key = secret_key
+    self.media_folder = media_folder
 
   @property
   def db_uri(self):

--- a/ruddock/modules/rotation/helpers.py
+++ b/ruddock/modules/rotation/helpers.py
@@ -54,11 +54,13 @@ def get_all_prefrosh():
   raw = flask.g.db.execute(query).fetchall()
   return postprocess_prefrosh_data(raw)
 
-def get_image_contents(prefrosh_id):
+
+def get_image_name(prefrosh_id):
+  """Return the filename of the image for the specified prefrosh."""
   query = sqlalchemy.text("""
-    SELECT image FROM rotation_prefrosh WHERE prefrosh_id = (:pid)
+    SELECT image_name FROM rotation_prefrosh WHERE prefrosh_id = (:pid)
     """)
-  return flask.g.db.execute(query, pid=prefrosh_id).first()['image']
+  return flask.g.db.execute(query, pid=prefrosh_id).first()['image_name']
 
 def update_comments(prefrosh_id, comments):
   query = sqlalchemy.text("""

--- a/ruddock/modules/rotation/routes.py
+++ b/ruddock/modules/rotation/routes.py
@@ -6,6 +6,7 @@ from ruddock.resources import Permissions
 from ruddock.decorators import login_required
 from ruddock.modules.rotation import blueprint, helpers
 
+PREFROSH_SUBDIR = "prefrosh_pics"
 
 @blueprint.route('/')
 @login_required(Permissions.ROTATION)
@@ -32,7 +33,7 @@ def show_prefrosh_list():
 def serve_image(prefrosh_id):
   """Retrieves a prefrosh's picture."""
   img_name = helpers.get_image_name(prefrosh_id)
-  dir_name = flask.current_app.config["MEDIA_FOLDER"] + "/prefrosh_pics"
+  dir_name = flask.current_app.config["MEDIA_FOLDER"] + '/' + PREFROSH_SUBDIR
   return flask.send_from_directory(dir_name, img_name);
 
 @blueprint.route('/prefrosh/<int:prefrosh_id>')

--- a/ruddock/modules/rotation/routes.py
+++ b/ruddock/modules/rotation/routes.py
@@ -53,6 +53,12 @@ def update_comment(prefrosh_id):
   helpers.update_votes(prefrosh_id, flask.request.form)
   return flask.redirect(flask.url_for("rotation.show_prefrosh", prefrosh_id=prefrosh_id))
 
+@blueprint.route('/compute_buckets', methods=['POST'])
+@login_required(Permissions.ROTATION)
+def compute_buckets():
+  helpers.compute_buckets()
+  return flask.redirect(flask.url_for("rotation.show_portal"))
+
 @blueprint.route('/move')
 @login_required(Permissions.ROTATION)
 def move():

--- a/ruddock/modules/rotation/routes.py
+++ b/ruddock/modules/rotation/routes.py
@@ -30,9 +30,10 @@ def show_prefrosh_list():
 @blueprint.route('/images/<int:prefrosh_id>')
 @login_required(Permissions.ROTATION)
 def serve_image(prefrosh_id):
-  img_contents = helpers.get_image_contents(prefrosh_id)
-  return flask.Response(response=io.BytesIO(img_contents), status='200 OK',
-            headers=None, mimetype='image/jpeg', content_type='image/jpeg')
+  """Retrieves a prefrosh's picture."""
+  img_name = helpers.get_image_name(prefrosh_id)
+  dir_name = flask.current_app.config["MEDIA_FOLDER"] + "/prefrosh_pics"
+  return flask.send_from_directory(dir_name, img_name);
 
 @blueprint.route('/prefrosh/<int:prefrosh_id>')
 @login_required(Permissions.ROTATION)

--- a/ruddock/modules/rotation/templates/portal.html
+++ b/ruddock/modules/rotation/templates/portal.html
@@ -16,6 +16,11 @@
     <a href="{{ url_for('rotation.show_prefrosh_list') }}">All Prefrosh</a>
   </div>
   <div class="menuItem">
+    <h2>Compute Buckets</h2>
+    <form action = "{{ url_for('rotation.compute_buckets') }}" method = "post">
+        <input type="submit" value="Go!">
+    </form>
+    <br>
     <h2>Move Prefrosh</h2>
     <form action="{{ url_for('rotation.move') }}" method="get" id="bucket_form">
       <label>Old Bucket:</label>
@@ -32,7 +37,7 @@
         {% endfor %}
       </select>
       <br>
-      <input type="submit">
+      <input type="submit" value="Compare Buckets">
     </form>
   </div>
 </div>


### PR DESCRIPTION
There's two main changes here:
One is to move prefrosh images from the database to a folder on the server. This makes your life easier when you realize "oh shit, I forgot to rotate this one prefrosh's image". The downside is that they have to be stored somewhere. Pretty sure I did it right, but I'm def looking for feedback on that part. That's going to require a config change on the server, but it shouldn't be too hard.

The other is reflecting the changes we made to bucketing. Namely: drop 000 bucket and use a single +1 dummy vote. Plus now there's a button do all that automatically, so you don't have to do the averages yourself.

The code's pretty messy, but rotation is coming soon, so, better messy than absent, I guess.