### PR TITLE
Fix validation script for new frosh UID scheme

### DIFF
--- a/ruddock/validation_utils.py
+++ b/ruddock/validation_utils.py
@@ -7,7 +7,7 @@ from ruddock import constants
 
 username_regex = re.compile(r'^[a-z][a-z0-9_-]*$', re.I)
 name_regex = re.compile(r"^[a-z][a-z '-]{0,30}[a-z]$", re.I)
-uid_regex = re.compile(r'^[0-9]{7}$')
+uid_regex = re.compile(r'^[0-9]{7,8}$')
 year_regex = re.compile(r'^[0-9]{4}$')
 email_regex = re.compile(r'^[a-z0-9\.\_\%\+\-]+@[a-z0-9\.\-]+\.[a-z]+$', re.I)
 


### PR DESCRIPTION
Frosh have UIDs like "2071xxxx" which is _8_ characters, not 7. I need to add frosh to the members list so the mailing list script will put them onto spam@, etc., so I went ahead and fixed it.