### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
 python:
   - "3.5"
-services:
-  - mariadb
-before_install:
-  - sudo apt-get install libmariadbclient-dev
+
+addons:
+  mariadb: "10.3"
+
 install:
   - pip install -r requirements.txt
-addons:
-  mariadb: "10.1"
 before_script:
   - mysql -u root < database/setup.sql
   - mysql -u ruddweb_test --password=public < database/reset.sql


### PR DESCRIPTION
Through a combination of things, I've gotten Travis to work again.
Not sure which of them fixed it though...
 - Removed mariadb from services (don't need it if it's in addons)
 - Upgraded to 10.3 <-- I think that's the fix
 - Dropped the libmariadbclient-dev installation, because I don't think
   it exists: https://packages.ubuntu.com/search?keywords=libmariadbclient-dev