### PR TITLE
Add link to ExComm materials to info.html

### DIFF
--- a/ruddock/routes.py
+++ b/ruddock/routes.py
@@ -17,6 +17,7 @@ def home():
 @login_required()
 def show_info():
   """Shows info page on door combos, printers, etc."""
+  # TODO - if desired, add excomm flag to show/hide ExComm Materials link
   return flask.render_template('info.html',
     full_member=is_full_member(flask.session['username']),
     secrets=secrets)

--- a/ruddock/templates/info.html
+++ b/ruddock/templates/info.html
@@ -2,12 +2,16 @@
 {% block body %}
 <h2>Useful House Info</h2>
 <br />
-<h3> Ruddock House Calendar (All times are Pacific Time: Los Angeles) </h3> 
+<h3> Ruddock House Calendar (All times are Pacific Time: Los Angeles) </h3>
 <iframe src="https://calendar.google.com/calendar/embed?src=qcgt4jno577tdmf8o3vs8k5354%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 <br />
 
 <h3>Past ExComm Meeting Minutes</h3>
 <p> Minutes from past meetings can be found <a href="{{ secrets.LINKS['ExComm_Meeting_Minutes'] }}">here</a>.
+</p>
+
+<h3>ExComm Communal Materials</h3>
+<p> Shared materials for ExComm can be found <a href="{{ secrets.LINKS['ExComm_Materials'] }}" target="_blank">here</a>.
 </p>
 
 <h3>Messenger Group Chats</h3>


### PR DESCRIPTION
Closes #207 

A private Google folder link for ExComm should be added to `secrets.py` for this commit to work.

For testing purposes, you can add this block to `default_secrets.py`:
```
LINKS = {
    'ExComm_Meeting_Minutes':'https://www.google.com',
    'ExComm_Materials':'https://www.caltech.edu'
}
```

The `is_excomm` db attribute could be used to show/hide the ExComm Materials on the info page (I left a TODO for this). 