### PR TITLE
Allow the expenses table to be downloadable as a csv.

### DIFF
--- a/ruddock/modules/budget/routes.py
+++ b/ruddock/modules/budget/routes.py
@@ -52,6 +52,13 @@ def route_expenses():
     ptypes=PaymentType.get_all())
 
 
+@blueprint.route('/expenses/download')
+@login_required(Permissions.BUDGET)
+def route_download_expenses():
+  """Downloads list of expenses."""
+  return helpers.download_expenses()
+
+
 @blueprint.route('/payments')
 @login_required(Permissions.BUDGET)
 def route_payments():
@@ -240,7 +247,7 @@ def route_delete_expense(expense_id, budget_id, date_incurred, amount, descripti
 
   flask.flash("Success!")
   return flask.redirect(flask.url_for("budget.route_expenses"))
-  
+
 
 @blueprint.route('/unpaid')
 @login_required(Permissions.BUDGET)

--- a/ruddock/modules/budget/templates/budget_portal.html
+++ b/ruddock/modules/budget/templates/budget_portal.html
@@ -25,4 +25,9 @@
   <!-- edit budget amounts -->
 </ul>
 
+<h3>Download</h3>
+<ul>
+  <li><a href="{{ url_for('budget.route_download_expenses') }}">Expenses</a></li>
+</ul>
+
 {% endblock body %}

--- a/ruddock/modules/budget/templates/expenses.html
+++ b/ruddock/modules/budget/templates/expenses.html
@@ -4,7 +4,7 @@
 
 {% block body %}
 
-<h2>Expense List</h2>
+<h2>Expense List (<a href="{{ url_for('budget.route_download_expenses') }}">download</a>)</h2>
 <table>
 
   <thead>


### PR DESCRIPTION
This allows a user with access to download a CSV with the expenses table, from the budget page or the expenses page.

For testing purposes, you can add this sample data to `test_data.sql`:
```
INSERT INTO user_permissions
  (user_id, permission_id)
  VALUES
  (1, 1);

INSERT INTO budget_accounts
  (account_name, initial_balance)
  VALUES
  ('FakeAccount1', 100.01),
  ('RealAccount10', 10000.99);

INSERT INTO budget_fyears
  (fyear_num, start_date, end_date)
  VALUES
  (2020, '2020-01-05', '2020-12-20'),
  (2021, '2021-01-07', '2021-11-30');

INSERT INTO budget_budgets
  (budget_name, fyear_id, starting_amount)
  VALUES
  ('soc-team', 1, 25.12),
  ('soc-team', 2, 10.12),
  ('pres', 1, 30.12),
  ('pres', 2, 5.12);

INSERT INTO budget_payees
  (payee_name)
  VALUES
  ('Rudd 1'),
  ('Rudd 2'),
  ('Rudd 3'),
  ('House 1'),
  ('House 2');

INSERT INTO budget_payments
  (account_id, payment_type, amount, date_written, date_posted, payee_id, check_no)
  VALUES
  (1, 1, 3.12, '2020-03-07', NULL, 2, NULL),
  (2, 2, 13.72, '2020-03-09', NULL, 1, 'C123456789');

INSERT INTO budget_expenses
   (budget_id, date_incurred, description, cost, payment_id, payee_id)
   VALUES
   (1, '2020-01-01', 'Expenses for something.', 1.01, NULL, 1),
   (1, '2020-03-08', 'Expenses for something.', 1.01, 2, 1);
``` 